### PR TITLE
feat: parallel testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
         id: start-local-node
         if: ${{ steps.build-sdk.conclusion == 'success' && !cancelled() && always() }}
         run: |
-          ${{ env.CG_EXEC }} npx @hashgraph/hedera-local start -d -—network local --balance=100000 --network-tag=0.57.0
+          ${{ env.CG_EXEC }} npx @hashgraph/hedera-local start -d -—network local --balance=10000000 --network-tag=0.57.0
           # Wait for the network to fully start
           sleep 30
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,11 +143,6 @@ jobs:
         if: ${{ steps.build-sdk.conclusion == 'success' && steps.stop-local-node.conclusion == 'success' && !cancelled() && always() }}
         run: ${{ env.CG_EXEC }} task build
 
-      - name: Unit Test @hashgraph/cryptography
-        working-directory: packages/cryptography
-        if: ${{ steps.build-sdk.conclusion == 'success' && steps.stop-local-node.conclusion == 'success' && !cancelled() && always() }}
-        run: ${{ env.CG_EXEC }} task test:unit
-
       - name: Codecov @hashgraph/cryptography
         working-directory: packages/cryptography
         if: ${{ steps.build-sdk.conclusion == 'success' && steps.stop-local-node.conclusion == 'success' && !cancelled() && always() }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,7 +149,7 @@ tasks:
 
     "test:integration:node":
         cmds:
-            - npx mocha --exit --parallel -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
+            - npx mocha --exit --parallel -jobs 4 -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
 
     "test:integration:codecov":
         cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -153,7 +153,7 @@ tasks:
 
     "test:integration:codecov":
         cmds:
-            - npx c8 --reporter=lcov --reporter=text-summary ./node_modules/.bin/mocha --exit -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
+            - npx c8 --reporter=lcov --reporter=text-summary ./node_modules/.bin/mocha --exit --parallel -jobs 4 -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
             - npx c8 report
 
     "update:proto":

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,7 +149,7 @@ tasks:
 
     "test:integration:node":
         cmds:
-            - npx mocha --exit -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
+            - npx mocha --exit --parallel -r @babel/register -r chai/register-expect.js "test/integration/*.js" --timeout 120000 {{.CLI_ARGS}}
 
     "test:integration:codecov":
         cmds:

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -278,35 +278,32 @@ export default class Query extends Executable {
         this._operator =
             this._operator != null ? this._operator : client._operator;
 
-        // If the payment transaction ID is not set
-        if (this._paymentTransactionId == null) {
-            // And payment is required
-            if (this._isPaymentRequired()) {
-                // Assign the account IDs to which the transaction should be sent.
-                this.transactionNodeIds = Object.values(client.network).map(
-                    (accountNodeId) => accountNodeId.toString(),
-                );
+        // And payment is required
+        if (this._isPaymentRequired()) {
+            // Assign the account IDs to which the transaction should be sent.
+            this.transactionNodeIds = Object.values(client.network).map(
+                (accountNodeId) => accountNodeId.toString(),
+            );
 
-                // And the client has an operator
-                if (this._operator != null) {
-                    // Generate the payment transaction ID
-                    this._paymentTransactionId = TransactionId.generate(
-                        this._operator.accountId,
-                    );
-                } else {
-                    // If payment is required, but an operator did not exist, throw an error
-                    throw new Error(
-                        "`client` must have an `operator` or an explicit payment transaction must be provided",
-                    );
-                }
-            } else {
-                // If the payment transaction ID is not set, but this query doesn't require a payment
-                // set the payment transaction ID to an empty transaction ID.
-                // FIXME: Should use `TransactionId.withValidStart()` instead
+            // And the client has an operator
+            if (this._operator != null) {
+                // Generate the payment transaction ID
                 this._paymentTransactionId = TransactionId.generate(
-                    new AccountId(0),
+                    this._operator.accountId,
+                );
+            } else {
+                // If payment is required, but an operator did not exist, throw an error
+                throw new Error(
+                    "`client` must have an `operator` or an explicit payment transaction must be provided",
                 );
             }
+        } else {
+            // If the payment transaction ID is not set, but this query doesn't require a payment
+            // set the payment transaction ID to an empty transaction ID.
+            // FIXME: Should use `TransactionId.withValidStart()` instead
+            this._paymentTransactionId = TransactionId.generate(
+                new AccountId(0),
+            );
         }
 
         let cost = new Hbar(0);

--- a/test/integration/ContractFunctionParametersIntegrationTest.js
+++ b/test/integration/ContractFunctionParametersIntegrationTest.js
@@ -1,4 +1,5 @@
 /* eslint-disable mocha/no-setup-in-describe */
+import { setTimeout } from "timers/promises";
 import {
     FileCreateTransaction,
     ContractCreateTransaction,
@@ -8,6 +9,7 @@ import {
     ContractDeleteTransaction,
     FileAppendTransaction,
     FileDeleteTransaction,
+    MirrorNodeContractEstimateQuery,
 } from "../../src/exports.js";
 import { REQUIRE_ARRAY_ERROR } from "../../src/util.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
@@ -146,6 +148,7 @@ describe("ContractFunctionParameters", function () {
             fileAppendRx.status.toString(10),
         );
 
+        await setTimeout(2500);
         // Instantiate the contract instance
         const contractTx = new ContractCreateTransaction()
             //Set the file ID of the Hedera file storing the bytecode
@@ -178,9 +181,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -213,9 +230,22 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -249,9 +279,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -283,9 +327,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -320,9 +378,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -356,9 +428,22 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -391,10 +476,24 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
+
                     const arr = createArray(bitSize, INPUT_TYPE.NUMBER);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -428,10 +527,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
                     const arr = createArray(bitSize, INPUT_TYPE.BIG_NUMBER);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -465,10 +577,23 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const gasEstimte =
+                        await new MirrorNodeContractEstimateQuery()
+                            .setContractId(newContractId)
+                            .setFunction(
+                                `returnInt${bitSize}`,
+                                new ContractFunctionParameters()[
+                                    `addInt${bitSize}`
+                                ](
+                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
+                                        .max,
+                                ),
+                            )
+                            .execute(env.client);
                     const arr = createArray(bitSize, INPUT_TYPE.LONG);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -496,9 +621,18 @@ describe("ContractFunctionParameters", function () {
             );
 
             it(`addInt${bitSize}Array method should return an empty array`, async function () {
+                const gasEstimte = await new MirrorNodeContractEstimateQuery()
+                    .setContractId(newContractId)
+                    .setFunction(
+                        `returnInt${bitSize}`,
+                        new ContractFunctionParameters()[`addInt${bitSize}`](
+                            calculateRange(bitSize, INPUT_TYPE.NUMBER).max,
+                        ),
+                    )
+                    .execute(env.client);
                 const contractQuery = new ContractCallQuery()
                     //Set the gas for the query
-                    .setGas(12000000)
+                    .setGas(gasEstimte)
                     //Set the contract ID to return the request for
                     .setContractId(newContractId)
                     //Set the contract function to call
@@ -522,10 +656,19 @@ describe("ContractFunctionParameters", function () {
             });
 
             it(`addInt${bitSize}Array method should throw an error`, async function () {
+                const gasEstimte = await new MirrorNodeContractEstimateQuery()
+                    .setContractId(newContractId)
+                    .setFunction(
+                        `returnInt${bitSize}`,
+                        new ContractFunctionParameters()[`addInt${bitSize}`](
+                            calculateRange(bitSize, INPUT_TYPE.NUMBER).max,
+                        ),
+                    )
+                    .execute(env.client);
                 try {
                     new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -556,7 +699,7 @@ describe("ContractFunctionParameters", function () {
                 async function () {
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -592,7 +735,7 @@ describe("ContractFunctionParameters", function () {
                 async function () {
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -629,7 +772,7 @@ describe("ContractFunctionParameters", function () {
                 async function () {
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -666,7 +809,7 @@ describe("ContractFunctionParameters", function () {
                     const arr = [0, range.min + range.max];
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -705,7 +848,7 @@ describe("ContractFunctionParameters", function () {
                     const arr = [0, new BigNumber(2).pow(bitSize - 1).minus(1)];
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -745,7 +888,7 @@ describe("ContractFunctionParameters", function () {
                     const arr = [0, new Long(range.min + range.max)];
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -777,7 +920,7 @@ describe("ContractFunctionParameters", function () {
             it(`addUint${bitSize}Array method should return an empty array`, async function () {
                 const contractQuery = new ContractCallQuery()
                     //Set the gas for the query
-                    .setGas(12000000)
+                    .setGas(1_500_000)
                     //Set the contract ID to return the request for
                     .setContractId(newContractId)
                     //Set the contract function to call
@@ -804,7 +947,7 @@ describe("ContractFunctionParameters", function () {
                 try {
                     new ContractCallQuery()
                         //Set the gas for the query
-                        .setGas(12000000)
+                        .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
@@ -828,7 +971,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the right min multiple int8 value", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -850,7 +993,7 @@ describe("ContractFunctionParameters", function () {
     it("should work the right way with 0 uint32 value", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -871,7 +1014,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the right multiple values", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -895,7 +1038,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the right multiple int40 values", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -917,7 +1060,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the right zero uint256 value", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -944,7 +1087,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the right 20 decimal uint256 value", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
@@ -971,7 +1114,7 @@ describe("ContractFunctionParameters", function () {
     it("should return the again right uint256 value", async function () {
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
-            .setGas(12000000)
+            .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call

--- a/test/integration/ContractFunctionParametersIntegrationTest.js
+++ b/test/integration/ContractFunctionParametersIntegrationTest.js
@@ -148,7 +148,6 @@ describe("ContractFunctionParameters", function () {
             fileAppendRx.status.toString(10),
         );
 
-        await setTimeout(2500);
         // Instantiate the contract instance
         const contractTx = new ContractCreateTransaction()
             //Set the file ID of the Hedera file storing the bytecode
@@ -163,6 +162,8 @@ describe("ContractFunctionParameters", function () {
 
         //Get the receipt of the file create transaction
         const contractReceipt = await contractResponse.getReceipt(env.client);
+
+        await setTimeout(2500);
 
         //Get the smart contract ID
         newContractId = contractReceipt.contractId;
@@ -181,18 +182,14 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](-calculateRange(bitSize, INPUT_TYPE.NUMBER).min);
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, contractParams)
                             .execute(env.client);
 
                     const contractQuery = new ContractCallQuery()
@@ -201,12 +198,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](-calculateRange(bitSize, INPUT_TYPE.NUMBER).min),
-                        )
+                        .setFunction(`returnInt${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -230,18 +222,14 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const functionParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](calculateRange(bitSize, INPUT_TYPE.NUMBER).max);
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, functionParams)
                             .execute(env.client);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
@@ -249,12 +237,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](calculateRange(bitSize, INPUT_TYPE.NUMBER).max),
-                        )
+                        .setFunction(`returnInt${bitSize}`, functionParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -279,18 +262,13 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](new BigNumber(-2).pow(bitSize - 1));
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, contractParams)
                             .execute(env.client);
 
                     const contractQuery = new ContractCallQuery()
@@ -299,12 +277,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](new BigNumber(-2).pow(bitSize - 1)),
-                        )
+                        .setFunction(`returnInt${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -327,18 +300,14 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](new BigNumber(2).pow(bitSize - 1).minus(1));
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, contractParams)
                             .execute(env.client);
 
                     const contractQuery = new ContractCallQuery()
@@ -347,12 +316,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](new BigNumber(2).pow(bitSize - 1).minus(1)),
-                        )
+                        .setFunction(`returnInt${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -378,18 +342,14 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](new Long(calculateRange(bitSize).min).neg());
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, contractParams)
                             .execute(env.client);
 
                     const contractQuery = new ContractCallQuery()
@@ -398,12 +358,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](new Long(calculateRange(bitSize).min).neg()),
-                        )
+                        .setFunction(`returnInt${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -428,18 +383,13 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}`
+                    ](new Long(calculateRange(bitSize).max));
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
-                            .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
-                            )
+                            .setFunction(`returnInt${bitSize}`, contractParams)
                             .execute(env.client);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
@@ -447,12 +397,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}`
-                            ](new Long(calculateRange(bitSize).max)),
-                        )
+                        .setFunction(`returnInt${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -476,33 +421,27 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const arr = createArray(bitSize, INPUT_TYPE.NUMBER);
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}Array`
+                    ](arr);
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
                             .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
+                                `returnInt${bitSize}Array`,
+                                contractParams,
                             )
                             .execute(env.client);
 
-                    const arr = createArray(bitSize, INPUT_TYPE.NUMBER);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}Array`
-                            ](arr),
-                        )
+                        .setFunction(`returnInt${bitSize}Array`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -527,20 +466,19 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const arr = createArray(bitSize, INPUT_TYPE.BIG_NUMBER);
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}Array`
+                    ](arr);
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
                             .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
+                                `returnInt${bitSize}Array`,
+                                contractParams,
                             )
                             .execute(env.client);
-                    const arr = createArray(bitSize, INPUT_TYPE.BIG_NUMBER);
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(gasEstimte)
@@ -577,32 +515,27 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.INT,
                 ),
                 async function () {
+                    const arr = createArray(bitSize, INPUT_TYPE.LONG);
+                    const contractParams = new ContractFunctionParameters()[
+                        `addInt${bitSize}Array`
+                    ](arr);
+
                     const gasEstimte =
                         await new MirrorNodeContractEstimateQuery()
                             .setContractId(newContractId)
                             .setFunction(
-                                `returnInt${bitSize}`,
-                                new ContractFunctionParameters()[
-                                    `addInt${bitSize}`
-                                ](
-                                    calculateRange(bitSize, INPUT_TYPE.NUMBER)
-                                        .max,
-                                ),
+                                `returnInt${bitSize}Array`,
+                                contractParams,
                             )
                             .execute(env.client);
-                    const arr = createArray(bitSize, INPUT_TYPE.LONG);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(gasEstimte)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}Array`
-                            ](arr),
-                        )
+                        .setFunction(`returnInt${bitSize}Array`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -621,14 +554,16 @@ describe("ContractFunctionParameters", function () {
             );
 
             it(`addInt${bitSize}Array method should return an empty array`, async function () {
+                const contractParams = new ContractFunctionParameters()[
+                    `addInt${bitSize}Array`
+                ](
+                    // eslint-disable-next-line no-loss-of-precision
+                    [],
+                );
+
                 const gasEstimte = await new MirrorNodeContractEstimateQuery()
                     .setContractId(newContractId)
-                    .setFunction(
-                        `returnInt${bitSize}`,
-                        new ContractFunctionParameters()[`addInt${bitSize}`](
-                            calculateRange(bitSize, INPUT_TYPE.NUMBER).max,
-                        ),
-                    )
+                    .setFunction(`returnInt${bitSize}Array`, contractParams)
                     .execute(env.client);
                 const contractQuery = new ContractCallQuery()
                     //Set the gas for the query
@@ -636,15 +571,7 @@ describe("ContractFunctionParameters", function () {
                     //Set the contract ID to return the request for
                     .setContractId(newContractId)
                     //Set the contract function to call
-                    .setFunction(
-                        `returnInt${bitSize}Array`,
-                        new ContractFunctionParameters()[
-                            `addInt${bitSize}Array`
-                        ](
-                            // eslint-disable-next-line no-loss-of-precision
-                            [],
-                        ),
-                    )
+                    .setFunction(`returnInt${bitSize}Array`, contractParams)
                     //Set the query payment for the node returning the request
                     //This value must cover the cost of the request otherwise will fail
                     .setQueryPayment(new Hbar(10));
@@ -656,14 +583,13 @@ describe("ContractFunctionParameters", function () {
             });
 
             it(`addInt${bitSize}Array method should throw an error`, async function () {
+                const contractParams = new ContractFunctionParameters()[
+                    `addInt${bitSize}`
+                ](calculateRange(bitSize, INPUT_TYPE.NUMBER).max);
+
                 const gasEstimte = await new MirrorNodeContractEstimateQuery()
                     .setContractId(newContractId)
-                    .setFunction(
-                        `returnInt${bitSize}`,
-                        new ContractFunctionParameters()[`addInt${bitSize}`](
-                            calculateRange(bitSize, INPUT_TYPE.NUMBER).max,
-                        ),
-                    )
+                    .setFunction(`returnInt${bitSize}`, contractParams)
                     .execute(env.client);
                 try {
                     new ContractCallQuery()
@@ -672,12 +598,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnInt${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addInt${bitSize}Array`
-                            ](),
-                        )
+                        .setFunction(`returnInt${bitSize}Array`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -697,18 +618,17 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.UINT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}`
+                    ](calculateRange(bitSize, INPUT_TYPE.NUMBER).max);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnUint${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}`
-                            ](calculateRange(bitSize, INPUT_TYPE.NUMBER).max),
-                        )
+                        .setFunction(`returnUint${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -733,18 +653,17 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.UINT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}`
+                    ](new BigNumber(2).pow(bitSize - 1).minus(1));
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnUint${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}`
-                            ](new BigNumber(2).pow(bitSize - 1).minus(1)),
-                        )
+                        .setFunction(`returnUint${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -770,18 +689,17 @@ describe("ContractFunctionParameters", function () {
                     METHOD_TYPE.UINT,
                 ),
                 async function () {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}`
+                    ](new Long(calculateRange(bitSize).max));
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
                         //Set the contract ID to return the request for
                         .setContractId(newContractId)
                         //Set the contract function to call
-                        .setFunction(
-                            `returnUint${bitSize}`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}`
-                            ](new Long(calculateRange(bitSize).max)),
-                        )
+                        .setFunction(`returnUint${bitSize}`, contractParams)
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
                         .setQueryPayment(new Hbar(10));
@@ -807,6 +725,10 @@ describe("ContractFunctionParameters", function () {
                 async function () {
                     const range = calculateRange(bitSize, INPUT_TYPE.NUMBER);
                     const arr = [0, range.min + range.max];
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}Array`
+                    ](arr);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
@@ -815,9 +737,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract function to call
                         .setFunction(
                             `returnUint${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}Array`
-                            ](arr),
+                            contractParams,
                         )
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
@@ -846,6 +766,10 @@ describe("ContractFunctionParameters", function () {
                 ),
                 async function () {
                     const arr = [0, new BigNumber(2).pow(bitSize - 1).minus(1)];
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}Array`
+                    ](arr);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
@@ -854,9 +778,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract function to call
                         .setFunction(
                             `returnUint${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}Array`
-                            ](arr),
+                            contractParams,
                         )
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
@@ -886,6 +808,10 @@ describe("ContractFunctionParameters", function () {
                 async function () {
                     const range = calculateRange(bitSize, INPUT_TYPE.NUMBER);
                     const arr = [0, new Long(range.min + range.max)];
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}Array`
+                    ](arr);
+
                     const contractQuery = new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
@@ -894,9 +820,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract function to call
                         .setFunction(
                             `returnUint${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}Array`
-                            ](arr),
+                            contractParams,
                         )
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
@@ -918,21 +842,20 @@ describe("ContractFunctionParameters", function () {
             );
 
             it(`addUint${bitSize}Array method should return an empty array`, async function () {
+                const contractParams = new ContractFunctionParameters()[
+                    `addUint${bitSize}Array`
+                ](
+                    // eslint-disable-next-line no-loss-of-precision
+                    [],
+                );
+
                 const contractQuery = new ContractCallQuery()
                     //Set the gas for the query
                     .setGas(1_500_000)
                     //Set the contract ID to return the request for
                     .setContractId(newContractId)
                     //Set the contract function to call
-                    .setFunction(
-                        `returnUint${bitSize}Array`,
-                        new ContractFunctionParameters()[
-                            `addUint${bitSize}Array`
-                        ](
-                            // eslint-disable-next-line no-loss-of-precision
-                            [],
-                        ),
-                    )
+                    .setFunction(`returnUint${bitSize}Array`, contractParams)
                     //Set the query payment for the node returning the request
                     //This value must cover the cost of the request otherwise will fail
                     .setQueryPayment(new Hbar(10));
@@ -945,6 +868,9 @@ describe("ContractFunctionParameters", function () {
 
             it(`addUint${bitSize}Array method should throw an error`, async function () {
                 try {
+                    const contractParams = new ContractFunctionParameters()[
+                        `addUint${bitSize}Array`
+                    ]();
                     new ContractCallQuery()
                         //Set the gas for the query
                         .setGas(1_500_000)
@@ -953,9 +879,7 @@ describe("ContractFunctionParameters", function () {
                         //Set the contract function to call
                         .setFunction(
                             `returnUint${bitSize}Array`,
-                            new ContractFunctionParameters()[
-                                `addUint${bitSize}Array`
-                            ](),
+                            contractParams,
                         )
                         //Set the query payment for the node returning the request
                         //This value must cover the cost of the request otherwise will fail
@@ -969,6 +893,7 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the right min multiple int8 value", async function () {
+        const contractParams = new ContractFunctionParameters().addInt8(-128);
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
@@ -977,7 +902,7 @@ describe("ContractFunctionParameters", function () {
             //Set the contract function to call
             .setFunction(
                 "returnInt8Multiple", // return two params: input & input (+) 20 // -128 + 20 = - 108
-                new ContractFunctionParameters().addInt8(-128),
+                contractParams,
             )
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
@@ -991,16 +916,14 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should work the right way with 0 uint32 value", async function () {
+        const contractParams = new ContractFunctionParameters().addUint32(0);
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnUint32",
-                new ContractFunctionParameters().addUint32(0),
-            )
+            .setFunction("returnUint32", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));
@@ -1012,16 +935,16 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the right multiple values", async function () {
+        const contractParams = new ContractFunctionParameters().addUint32(
+            4294967295,
+        );
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnMultipleTypeParams",
-                new ContractFunctionParameters().addUint32(4294967295),
-            )
+            .setFunction("returnMultipleTypeParams", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));
@@ -1036,16 +959,16 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the right multiple int40 values", async function () {
+        const contractParams = new ContractFunctionParameters().addInt40(
+            549755813885,
+        );
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnMultipleInt40",
-                new ContractFunctionParameters().addInt40(549755813885),
-            )
+            .setFunction("returnMultipleInt40", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));
@@ -1058,19 +981,17 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the right zero uint256 value", async function () {
+        const contractParams = new ContractFunctionParameters().addUint256(
+            // eslint-disable-next-line no-loss-of-precision
+            0,
+        );
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnUint256",
-                new ContractFunctionParameters().addUint256(
-                    // eslint-disable-next-line no-loss-of-precision
-                    0,
-                ),
-            )
+            .setFunction("returnUint256", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));
@@ -1085,19 +1006,17 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the right 20 decimal uint256 value", async function () {
+        const contractParams = new ContractFunctionParameters().addUint256(
+            // eslint-disable-next-line no-loss-of-precision
+            5000000000000000000000,
+        );
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnUint256",
-                new ContractFunctionParameters().addUint256(
-                    // eslint-disable-next-line no-loss-of-precision
-                    5000000000000000000000,
-                ),
-            )
+            .setFunction("returnUint256", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));
@@ -1112,19 +1031,17 @@ describe("ContractFunctionParameters", function () {
     });
 
     it("should return the again right uint256 value", async function () {
+        const contractParams = new ContractFunctionParameters().addUint256(
+            // eslint-disable-next-line no-loss-of-precision
+            50,
+        );
         const contractQuery = new ContractCallQuery()
             //Set the gas for the query
             .setGas(1_500_000)
             //Set the contract ID to return the request for
             .setContractId(newContractId)
             //Set the contract function to call
-            .setFunction(
-                "returnUint256",
-                new ContractFunctionParameters().addUint256(
-                    // eslint-disable-next-line no-loss-of-precision
-                    50,
-                ),
-            )
+            .setFunction("returnUint256", contractParams)
             //Set the query payment for the node returning the request
             //This value must cover the cost of the request otherwise will fail
             .setQueryPayment(new Hbar(10));

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -15,7 +15,7 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 ]);
 const DER_PUBLIC_KEY =
     "302d300706052b8104000a032200033697a2b3f9f0b9f4831b39986f7f3885636a3e8622a0bc3814a4a56f7ecdc4f1";
-const STRESS_TEST_ITERATION_COUNT = 1000;
+const STRESS_TEST_ITERATION_COUNT = 100;
 
 describe("EcdsaPrivateKey", function () {
     it("generate should return object", function () {

--- a/test/unit/Ed25519PrivateKey.js
+++ b/test/unit/Ed25519PrivateKey.js
@@ -15,7 +15,7 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 const DER_PUBLIC_KEY =
     "302a300506032b65700321004a6892f034d2d1c9b1a76acca8e34884055172f4210a0c02e3c7d55084f224d1";
 
-const STRESS_TEST_ITERATION_COUNT = 1000;
+const STRESS_TEST_ITERATION_COUNT = 100;
 
 describe("Ed25519PrivateKey", function () {
     it("generate should return  object", function () {


### PR DESCRIPTION
**Description**:

- Parallel testing in miltiple threads to increase test execution speed.  
- Use `MirrorNodeContractCallQuery` where applicable to circumvent throttle mechanic
- reduce stress iteration count to improve unit test speed
- remove backoff mechanism when running on local-node
- increase retry attempts when running on local node

**Fixes** #2710 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
