### PR TITLE
chore(fix): resolve incompatibility with latest pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "@types/chai": "^4.3.4",
         "@types/crypto-js": "^4.2.0",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^20.8.10",
+        "@types/node": "^22.0.0",
         "@types/utf8": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.62.0",
@@ -116,8 +116,8 @@
         "nyc": "^17.1.0",
         "prettier": "^3.0.3",
         "sinon": "^19.0.2",
-        "typescript": "^5.7.2",
         "typedoc": "^0.27.6",
+        "typescript": "^5.7.2",
         "vite": "^5.3.5",
         "yalc": "1.0.0-pre.53"
     },

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -98,6 +98,7 @@
         "@types/elliptic": "^6.4.14",
         "@types/node-forge": "^1.3.4",
         "@types/spark-md5": "^3.0.2",
+        "@types/node": "^22.0.0",
         "@types/utf8": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",

--- a/packages/cryptography/pnpm-lock.yaml
+++ b/packages/cryptography/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/elliptic':
         specifier: ^6.4.14
         version: 6.4.14
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.12.0
       '@types/node-forge':
         specifier: ^1.3.4
         version: 1.3.5
@@ -161,7 +164,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.3
-        version: 4.5.3(@types/node@20.6.2)
+        version: 4.5.3(@types/node@22.12.0)
 
 packages:
 
@@ -1282,8 +1285,8 @@ packages:
   '@types/node-forge@1.3.5':
     resolution: {integrity: sha512-GASdDr5u+BDTUcmWaS9Ljs1QTcyI+iPuCh/FdpDqLuLJP7Stx+j3DI0g4/cBn0zFjOnajMKATkq6PqBD0K5uzQ==}
 
-  '@types/node@20.6.2':
-    resolution: {integrity: sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/semver@7.5.2':
     resolution: {integrity: sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==}
@@ -4495,6 +4498,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -6093,7 +6099,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.6.2
+      '@types/node': 22.12.0
       '@types/yargs': 15.0.15
       chalk: 4.1.2
 
@@ -6163,7 +6169,7 @@ snapshots:
 
   '@types/bn.js@5.1.2':
     dependencies:
-      '@types/node': 20.6.2
+      '@types/node': 22.12.0
 
   '@types/crypto-js@4.2.1': {}
 
@@ -6187,9 +6193,11 @@ snapshots:
 
   '@types/node-forge@1.3.5':
     dependencies:
-      '@types/node': 20.6.2
+      '@types/node': 22.12.0
 
-  '@types/node@20.6.2': {}
+  '@types/node@22.12.0':
+    dependencies:
+      undici-types: 6.20.0
 
   '@types/semver@7.5.2': {}
 
@@ -6205,7 +6213,7 @@ snapshots:
 
   '@types/yauzl@2.10.0':
     dependencies:
-      '@types/node': 20.6.2
+      '@types/node': 22.12.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.52.0)(typescript@5.7.3))(eslint@8.52.0)(typescript@5.7.3)':
@@ -9735,6 +9743,8 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  undici-types@6.20.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -9846,13 +9856,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@4.5.3(@types/node@20.6.2):
+  vite@4.5.3(@types/node@22.12.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.4.30
       rollup: 3.29.5
     optionalDependencies:
-      '@types/node': 20.6.2
+      '@types/node': 22.12.0
       fsevents: 2.3.3
 
   wcwidth@1.0.1:

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -42,6 +42,7 @@
         "@babel/core": "^7.23.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-modules-commonjs": "^7.20.11",
+        "@types/node": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/packages/proto/pnpm-lock.yaml
+++ b/packages/proto/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@babel/plugin-transform-runtime':
         specifier: ^7.25.9
         version: 7.25.9(@babel/core@7.23.3)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.12.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.62.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.52.0)(typescript@5.7.3))(eslint@8.52.0)(typescript@5.7.3)
@@ -497,8 +500,8 @@ packages:
   '@types/mdurl@1.0.2':
     resolution: {integrity: sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==}
 
-  '@types/node@18.6.3':
-    resolution: {integrity: sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/semver@7.5.0':
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
@@ -2121,6 +2124,9 @@ packages:
   underscore@1.13.4:
     resolution: {integrity: sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==}
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
@@ -2691,7 +2697,9 @@ snapshots:
 
   '@types/mdurl@1.0.2': {}
 
-  '@types/node@18.6.3': {}
+  '@types/node@22.12.0':
+    dependencies:
+      undici-types: 6.20.0
 
   '@types/semver@7.5.0': {}
 
@@ -4253,7 +4261,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.6.3
+      '@types/node': 22.12.0
       long: 5.2.3
 
   punycode@2.1.1: {}
@@ -4612,6 +4620,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   underscore@1.13.4: {}
+
+  undici-types@6.20.0: {}
 
   untildify@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.10
       '@types/node':
-        specifier: ^20.8.10
-        version: 20.17.7
+        specifier: ^22.0.0
+        version: 22.12.0
       '@types/utf8':
         specifier: ^3.0.1
         version: 3.0.3
@@ -203,13 +203,12 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^5.3.5
-        version: 5.4.11(@types/node@20.17.7)
+        version: 5.4.11(@types/node@22.12.0)
       yalc:
         specifier: 1.0.0-pre.53
         version: 1.0.0-pre.53
 
 packages:
-
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
@@ -1539,8 +1538,8 @@ packages:
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
-  '@types/node@20.17.7':
-    resolution: {integrity: sha512-sZXXnpBFMKbao30dUAvzKbdwA2JM1fwUtVEq/kxKuPI5mMwZiRElCpTXb0Biq/LMEVpXDZL5G5V0RPnxKeyaYg==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -4948,8 +4947,8 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -6686,7 +6685,7 @@ snapshots:
   '@grpc/grpc-js@1.8.2':
     dependencies:
       '@grpc/proto-loader': 0.7.13
-      '@types/node': 20.17.7
+      '@types/node': 22.12.0
 
   '@grpc/proto-loader@0.7.13':
     dependencies:
@@ -6751,7 +6750,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.7
+      '@types/node': 22.12.0
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -6958,9 +6957,9 @@ snapshots:
 
   '@types/mocha@10.0.10': {}
 
-  '@types/node@20.17.7':
+  '@types/node@22.12.0':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@types/semver@7.5.8': {}
 
@@ -6976,7 +6975,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.7
+      '@types/node': 22.12.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
@@ -10015,7 +10014,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.17.7
+      '@types/node': 22.12.0
       long: 5.2.3
 
   proxy-agent@6.5.0:
@@ -10814,7 +10813,7 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -10901,13 +10900,13 @@ snapshots:
     dependencies:
       builtins: 1.0.3
 
-  vite@5.4.11(@types/node@20.17.7):
+  vite@5.4.11(@types/node@22.12.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.27.4
     optionalDependencies:
-      '@types/node': 20.17.7
+      '@types/node': 22.12.0
       fsevents: 2.3.3
 
   wcwidth@1.0.1:


### PR DESCRIPTION
Description:
This PR fixes issue with failing task install script due to types/node version incompatibility for pnpm versions greater than or equal to 9.

Related issue(s):
https://github.com/hiero-ledger/hiero-sdk-js/issues/2828

Checklist

- [x] Bump types/node to version ^22.x.
