### PR TITLE
feat: account create transaction with key derived alias

### DIFF
--- a/examples/account-allowance.js
+++ b/examples/account-allowance.js
@@ -46,7 +46,7 @@ async function main() {
 
     try {
         let transaction = await new AccountCreateTransaction()
-            .setKey(aliceKey)
+            .setKeyWithoutAlias(aliceKey)
             .setInitialBalance(new Hbar(5))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);
@@ -55,7 +55,7 @@ async function main() {
         const aliceId = (await response.getReceiptWithSigner(wallet)).accountId;
 
         transaction = await new AccountCreateTransaction()
-            .setKey(bobKey)
+            .setKeyWithoutAlias(bobKey)
             .setInitialBalance(new Hbar(5))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);
@@ -67,7 +67,7 @@ async function main() {
         ).accountId;
 
         transaction = await new AccountCreateTransaction()
-            .setKey(charlieKey)
+            .setKeyWithoutAlias(charlieKey)
             .setInitialBalance(new Hbar(5))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);

--- a/examples/create-account-with-alias-and-receiver-signature.js
+++ b/examples/create-account-with-alias-and-receiver-signature.js
@@ -83,7 +83,7 @@ async function main() {
         const accountCreateTx = new AccountCreateTransaction()
             .setReceiverSignatureRequired(true)
             .setInitialBalance(Hbar.fromTinybars(100))
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .setAlias(evmAddress)
             .freezeWith(client);
 

--- a/examples/create-account-with-alias.js
+++ b/examples/create-account-with-alias.js
@@ -4,7 +4,6 @@ import {
     Client,
     Hbar,
     AccountInfoQuery,
-    TransactionReceiptQuery,
     AccountCreateTransaction,
 } from "@hashgraph/sdk";
 
@@ -74,39 +73,26 @@ async function main() {
          *
          * Use the `AccountCreateTransaction`
          *   - Populate `setAlias(evmAddress)` field with the Ethereum public address
-         */
-        const accountCreateTx = new AccountCreateTransaction()
-            .setInitialBalance(Hbar.fromTinybars(100))
-            .setKeyWithoutAlias(operatorKey)
-            .setAlias(evmAddress)
-            .freezeWith(client);
-
-        /**
-         *
-         * Step 5
-         *
          * Sign the `AccountCreateTransaction` transaction with both the new private key and key paying for the transaction fee
-         */
-        const accountCreateTxSign = await accountCreateTx.sign(privateKey);
-        const accountCreateTxResponse =
-            await accountCreateTxSign.execute(client);
-
-        /**
-         *
-         * Step 6
-         *
          * Get the account ID of the newly created account
          */
-        const receipt = await new TransactionReceiptQuery()
-            .setTransactionId(accountCreateTxResponse.transactionId)
-            .execute(client);
+        const receipt = await (
+            await (
+                await new AccountCreateTransaction()
+                    .setInitialBalance(Hbar.fromTinybars(100))
+                    .setKeyWithoutAlias(operatorKey)
+                    .setAlias(evmAddress)
+                    .freezeWith(client)
+                    .sign(privateKey)
+            ).execute(client)
+        ).getReceipt(client);
 
         const newAccountId = receipt.accountId.toString();
         console.log(`Account ID of the newly created account: ${newAccountId}`);
 
         /**
          *
-         * Step 7
+         * Step 5
          *
          * Get the `AccountInfo` and show that the account has contractAccountId
          */
@@ -114,11 +100,154 @@ async function main() {
             .setAccountId(newAccountId)
             .execute(client);
 
-        accountInfo.contractAccountId !== null
-            ? console.log(
-                  `The newly created account has an alias: ${accountInfo.contractAccountId}`,
-              )
-            : console.log(`The new account doesn't have an alias`);
+        console.log(
+            `The newly created account has an alias: ${accountInfo.contractAccountId}`,
+        );
+    } catch (error) {
+        console.error(error);
+    }
+
+    /* Create an account with derived EVM alias from private ECDSA account key
+     *
+     * Reference: [Streamline key and alias specifications for AccountCreateTransaction #2795](https://github.com/hiero-ledger/hiero-sdk-js/issues/2795)
+     */
+    console.log(
+        "---Create an account with derived EVM alias from private ECDSA account key---",
+    );
+
+    try {
+        /**
+         * Step 1
+         *
+         * Create an ECSDA private key
+         */
+        const privateKey = PrivateKey.generateECDSA();
+        console.log(`Private key: ${privateKey.toStringDer()}`);
+
+        /**
+         *
+         * Step 2
+         *
+         * Use the `AccountCreateTransaction`
+         *   - Populate `setECDSAKeyWithAlias(privateKey)` field with the generated ECDSA private key
+         * Sign the `AccountCreateTransaction` transaction with the generated private key and execute it
+         * Get the account ID of the newly created account
+         */
+
+        const receipt = await (
+            await (
+                await new AccountCreateTransaction()
+                    .setInitialBalance(Hbar.fromTinybars(100))
+                    .setECDSAKeyWithAlias(privateKey)
+                    .freezeWith(client)
+                    .sign(privateKey)
+            ).execute(client)
+        ).getReceipt(client);
+
+        const newAccountId = receipt.accountId.toString();
+        console.log(`Account ID of the newly created account: ${newAccountId}`);
+
+        /**
+         *
+         * Step 3
+         *
+         * Get the `AccountInfo` and examine the created account key and alias
+         */
+        const accountInfo = await new AccountInfoQuery()
+            .setAccountId(newAccountId)
+            .execute(client);
+
+        console.log(
+            `Account's key ${accountInfo.key.toString()} is the same as ${privateKey.publicKey.toStringDer()}`,
+        );
+
+        if (
+            !accountInfo.contractAccountId.startsWith(
+                "000000000000000000000000",
+            )
+        ) {
+            console.log(
+                `Initial EVM address: ${privateKey.publicKey.toEvmAddress()} is the same as ${
+                    accountInfo.contractAccountId
+                }`,
+            );
+        } else {
+            console.log(`The new account doesn't have an EVM alias`);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+
+    /* Create an account with derived EVM alias from private ECDSA alias key
+     *
+     * Reference: [Streamline key and alias specifications for AccountCreateTransaction #2795](https://github.com/hiero-ledger/hiero-sdk-js/issues/2795)
+     */
+
+    console.log(
+        "---Create an account with derived EVM alias from private ECDSA alias key---",
+    );
+
+    try {
+        /**
+         * Step 1
+         *
+         * Create an account key and an ECSDA private alias key
+         */
+        const key = PrivateKey.generateED25519();
+        const aliasKey = PrivateKey.generateECDSA();
+        console.log(`Alias key: ${aliasKey.toStringDer()}`);
+
+        /**
+         *
+         * Step 2
+         *
+         * Use the `AccountCreateTransaction`
+         *   - Populate `setKeyWithAlias(key, privateKey)` fields with the generated account key and the alias ECDSA private key
+         * Sign the `AccountCreateTransaction` transaction with both keys and execute.
+         * Get the account ID of the newly created account
+         *
+         */
+
+        const receipt = await (
+            await (
+                await (
+                    await new AccountCreateTransaction()
+                        .setInitialBalance(Hbar.fromTinybars(100))
+                        .setKeyWithAlias(key, aliasKey)
+                        .freezeWith(client)
+                        .sign(key)
+                ).sign(aliasKey)
+            ).execute(client)
+        ).getReceipt(client);
+
+        const newAccountId = receipt.accountId.toString();
+        console.log(`Account ID of the newly created account: ${newAccountId}`);
+
+        /**
+         *
+         * Step 3
+         *
+         * Get the `AccountInfo` and examine the created account key and alias
+         */
+        const accountInfo = await new AccountInfoQuery()
+            .setAccountId(newAccountId)
+            .execute(client);
+
+        console.log(
+            `Account's key ${accountInfo.key.toString()} is the same as ${key.publicKey.toString()}`,
+        );
+
+        if (
+            !accountInfo.contractAccountId.startsWith(
+                "000000000000000000000000",
+            )
+        ) {
+            console.log(
+                `Initial EVM address: ${accountInfo.contractAccountId} is the same as ${aliasKey.publicKey.toEvmAddress()}`,
+            );
+        } else {
+            console.log(`The new account doesn't have an alias`);
+        }
     } catch (error) {
         console.error(error);
     }

--- a/examples/create-account-with-alias.js
+++ b/examples/create-account-with-alias.js
@@ -77,7 +77,7 @@ async function main() {
          */
         const accountCreateTx = new AccountCreateTransaction()
             .setInitialBalance(Hbar.fromTinybars(100))
-            .setKey(operatorKey)
+            .setKeyWithoutAlias(operatorKey)
             .setAlias(evmAddress)
             .freezeWith(client);
 

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -82,7 +82,7 @@ async function main() {
          */
         console.log("Creating new account...");
         const accountCreateTxResponse = await new AccountCreateTransaction()
-            .setKey(thresholdKey)
+            .setKeyWithoutAlias(thresholdKey)
             .setInitialBalance(new Hbar(100))
             .execute(client);
 

--- a/examples/create-account.js
+++ b/examples/create-account.js
@@ -37,7 +37,7 @@ async function main() {
     try {
         let transaction = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(10)) // 10 h
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .freezeWithSigner(wallet);
 
         transaction = await transaction.signWithSigner(wallet);

--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -38,7 +38,7 @@ async function main() {
     try {
         let transaction = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(10)) // 10 h
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);
         const response = await transaction.executeWithSigner(wallet);

--- a/examples/exempt-custom-fees.js
+++ b/examples/exempt-custom-fees.js
@@ -62,7 +62,7 @@ async function main() {
     let firstAccountPublicKey = firstAccountPrivateKey.publicKey;
 
     let createAccountAtx = await new AccountCreateTransaction()
-        .setKey(firstAccountPublicKey)
+        .setKeyWithoutAlias(firstAccountPublicKey)
         .setInitialBalance(Hbar.fromString("1000"))
         .freezeWithSigner(wallet);
     createAccountAtx = await createAccountAtx.signWithSigner(wallet);
@@ -81,7 +81,7 @@ async function main() {
     let secondAccountPublicKey = secondAccountPrivateKey.publicKey;
 
     let createAccountBtx = await new AccountCreateTransaction()
-        .setKey(secondAccountPublicKey)
+        .setKeyWithoutAlias(secondAccountPublicKey)
         .setInitialBalance(Hbar.fromString("1000"))
         .freezeWithSigner(wallet);
     createAccountBtx = await createAccountBtx.signWithSigner(wallet);
@@ -100,7 +100,7 @@ async function main() {
     let thirdAccountPublicKey = thirdAccountPrivateKey.publicKey;
 
     let createAccountCtx = await new AccountCreateTransaction()
-        .setKey(thirdAccountPublicKey)
+        .setKeyWithoutAlias(thirdAccountPublicKey)
         .setInitialBalance(Hbar.fromString("1000"))
         .freezeWithSigner(wallet);
     createAccountCtx = await createAccountCtx.signWithSigner(wallet);

--- a/examples/generate-txid-on-demand.js
+++ b/examples/generate-txid-on-demand.js
@@ -80,7 +80,7 @@ async function main() {
 
         const accountCreateTx = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(10)) // 10 h
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .freezeWith(client)
             .execute(client);
 

--- a/examples/initialize-client-with-mirror-node-adress-book.js
+++ b/examples/initialize-client-with-mirror-node-adress-book.js
@@ -39,7 +39,7 @@ async function main() {
     try {
         let transaction = new AccountCreateTransaction()
             .setInitialBalance(new Hbar(1))
-            .setKey(accountKey)
+            .setKeyWithoutAlias(accountKey)
             .freezeWith(client);
 
         transaction = await transaction.sign(accountKey);

--- a/examples/long-term-schedule-transaction.js
+++ b/examples/long-term-schedule-transaction.js
@@ -48,7 +48,7 @@ async function main() {
     const aliceId = (
         await (
             await new AccountCreateTransaction()
-                .setKey(thresholdKey)
+                .setKeyWithoutAlias(thresholdKey)
                 .setInitialBalance(new Hbar(2))
                 .execute(client)
         ).getReceipt(client)

--- a/examples/multi-node-multi-signature-remove.js
+++ b/examples/multi-node-multi-signature-remove.js
@@ -62,7 +62,7 @@ async function main() {
 
     const createAccountTransaction = new AccountCreateTransaction()
         .setInitialBalance(new Hbar(2))
-        .setKey(keyList);
+        .setKeyWithoutAlias(keyList);
 
     const createResponse = await createAccountTransaction.execute(client);
     const createReceipt = await createResponse.getReceipt(client);

--- a/examples/multi-node-multi-signature-removeAll.js
+++ b/examples/multi-node-multi-signature-removeAll.js
@@ -63,7 +63,7 @@ async function main() {
      */
     const createAccountTransaction = new AccountCreateTransaction()
         .setInitialBalance(new Hbar(2))
-        .setKey(keyList);
+        .setKeyWithoutAlias(keyList);
 
     const createResponse = await createAccountTransaction.execute(client);
     const createReceipt = await createResponse.getReceipt(client);

--- a/examples/multi-node-multi-signature.js
+++ b/examples/multi-node-multi-signature.js
@@ -57,7 +57,7 @@ async function main() {
 
     const createAccountTransaction = new AccountCreateTransaction()
         .setInitialBalance(new Hbar(2))
-        .setKey(keyList);
+        .setKeyWithoutAlias(keyList);
 
     const createResponse = await createAccountTransaction.execute(client);
     const createReceipt = await createResponse.getReceipt(client);

--- a/examples/multi-sig-offline.js
+++ b/examples/multi-sig-offline.js
@@ -48,7 +48,7 @@ async function main() {
 
     const createAccountTransaction = new AccountCreateTransaction()
         .setInitialBalance(new Hbar(2)) // 5 h
-        .setKey(keyList);
+        .setKeyWithoutAlias(keyList);
 
     const response = await createAccountTransaction.execute(client);
 

--- a/examples/nft-add-remove-allowances.js
+++ b/examples/nft-add-remove-allowances.js
@@ -103,7 +103,7 @@ async function main() {
         // Create `spender` account
         const spenderKey = PrivateKey.generateECDSA();
         const createSpenderTx = await new AccountCreateTransaction()
-            .setKey(spenderKey)
+            .setKeyWithoutAlias(spenderKey)
             .setInitialBalance(new Hbar(2))
             .execute(client);
 
@@ -114,7 +114,7 @@ async function main() {
         // Create `receiver` account
         const receiverKey = PrivateKey.generateECDSA();
         const createReceiverTx = await new AccountCreateTransaction()
-            .setKey(receiverKey)
+            .setKeyWithoutAlias(receiverKey)
             .setInitialBalance(new Hbar(2))
             .execute(client);
         const receiverAccountId = (await createReceiverTx.getReceipt(client))
@@ -280,7 +280,7 @@ async function main() {
         // Create `delegating spender` account
         const delegatingSpenderKey = PrivateKey.generateECDSA();
         const createDelegateSpenderTx = await new AccountCreateTransaction()
-            .setKey(delegatingSpenderKey)
+            .setKeyWithoutAlias(delegatingSpenderKey)
             .setInitialBalance(new Hbar(2))
             .execute(client);
 
@@ -294,7 +294,7 @@ async function main() {
         // Create `receiver` account
         const receiverKey2 = PrivateKey.generateECDSA();
         const createReceiverTx2 = await new AccountCreateTransaction()
-            .setKey(receiverKey2)
+            .setKeyWithoutAlias(receiverKey2)
             .setInitialBalance(new Hbar(2))
             .execute(client);
         const receiverAccountId2 = (await createReceiverTx2.getReceipt(client))
@@ -359,7 +359,7 @@ async function main() {
         // Create `spender` account
         const spenderKey2 = PrivateKey.generateECDSA();
         const createSpenderTx2 = await new AccountCreateTransaction()
-            .setKey(spenderKey2)
+            .setKeyWithoutAlias(spenderKey2)
             .setInitialBalance(new Hbar(2))
             .execute(client);
 

--- a/examples/schedule-example.js
+++ b/examples/schedule-example.js
@@ -43,7 +43,7 @@ async function main() {
 
     try {
         let transaction = await new AccountCreateTransaction()
-            .setKey(KeyList.of(key1.publicKey, key2.publicKey))
+            .setKeyWithoutAlias(KeyList.of(key1.publicKey, key2.publicKey))
             .setInitialBalance(20)
             .setStakedAccountId("0.0.3")
             .freezeWithSigner(wallet);

--- a/examples/scheduled-transaction-multi-sig-threshold.js
+++ b/examples/scheduled-transaction-multi-sig-threshold.js
@@ -57,7 +57,7 @@ async function main() {
     try {
         // create multi-sig account
         let transaction = await new AccountCreateTransaction()
-            .setKey(thresholdKey)
+            .setKeyWithoutAlias(thresholdKey)
             .setInitialBalance(Hbar.fromTinybars(1))
             .setAccountMemo("3-of-4 multi-sig account")
             .freezeWithSigner(wallet);

--- a/examples/sign-transaction.js
+++ b/examples/sign-transaction.js
@@ -44,7 +44,7 @@ async function main() {
     try {
         let transaction = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(2)) // 5 h
-            .setKey(keyList)
+            .setKeyWithoutAlias(keyList)
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);
         const response = await transaction.executeWithSigner(wallet);

--- a/examples/solidity-precompile-example.js
+++ b/examples/solidity-precompile-example.js
@@ -38,7 +38,7 @@ async function main() {
 
     try {
         let transaction = await new hashgraph.AccountCreateTransaction()
-            .setKey(alicePublicKey)
+            .setKeyWithoutAlias(alicePublicKey)
             .setInitialBalance(hashgraph.Hbar.fromString("1000"))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);

--- a/examples/staking-example-1.js
+++ b/examples/staking-example-1.js
@@ -42,7 +42,7 @@ async function main() {
         // If you really want to stake to node 0, you should use
         // `.setStakedNodeId()` instead
         let transaction = await new AccountCreateTransaction()
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .setInitialBalance(20)
             .setStakedAccountId("0.0.3")
             .freezeWithSigner(wallet);

--- a/examples/staking-example-2.js
+++ b/examples/staking-example-2.js
@@ -41,7 +41,7 @@ async function main() {
         // If you really want to stake to node 0, you should use
         // `.setStakedNodeId()` instead
         let transaction = await new AccountCreateTransaction()
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .setInitialBalance(20)
             .setStakedAccountId("0.0.3")
             .freezeWithSigner(wallet);

--- a/examples/time-drift.js
+++ b/examples/time-drift.js
@@ -66,7 +66,7 @@ async function main() {
 
     const response = await new AccountCreateTransaction()
         .setInitialBalance(10) // 10 h
-        .setKey(newKey.publicKey)
+        .setKeyWithoutAlias(newKey.publicKey)
         .execute(client);
 
     const receipt = await response.getReceipt(client);

--- a/examples/token-airdrop-example.js
+++ b/examples/token-airdrop-example.js
@@ -48,19 +48,19 @@ async function main() {
      * Create 4 accounts
      */
 
-    const privateKey = PrivateKey.generateED25519();
+    const privateKey = PrivateKey.generateECDSA();
     const { accountId: accountId1 } = await (
         await new AccountCreateTransaction()
-            .setKeyWithAlias(privateKey)
+            .setECDSAKeyWithAlias(privateKey)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(-1)
             .execute(client)
     ).getReceipt(client);
 
-    const privateKey2 = PrivateKey.generateED25519();
+    const privateKey2 = PrivateKey.generateECDSA();
     const { accountId: accountId2 } = await (
         await new AccountCreateTransaction()
-            .setKeyWithAlias(privateKey2)
+            .setECDSAKeyWithAlias(privateKey2)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(1)
             .execute(client)
@@ -75,10 +75,10 @@ async function main() {
             .execute(client)
     ).getReceipt(client);
 
-    const treasuryKey = PrivateKey.generateED25519();
+    const treasuryKey = PrivateKey.generateECDSA();
     const { accountId: treasuryAccount } = await (
         await new AccountCreateTransaction()
-            .setKeyWithAlias(treasuryKey)
+            .setECDSAKeyWithAlias(treasuryKey)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(-1)
             .execute(client)

--- a/examples/token-airdrop-example.js
+++ b/examples/token-airdrop-example.js
@@ -51,7 +51,7 @@ async function main() {
     const privateKey = PrivateKey.generateED25519();
     const { accountId: accountId1 } = await (
         await new AccountCreateTransaction()
-            .setKey(privateKey)
+            .setKeyWithAlias(privateKey)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(-1)
             .execute(client)
@@ -60,7 +60,7 @@ async function main() {
     const privateKey2 = PrivateKey.generateED25519();
     const { accountId: accountId2 } = await (
         await new AccountCreateTransaction()
-            .setKey(privateKey2)
+            .setKeyWithAlias(privateKey2)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(1)
             .execute(client)
@@ -69,7 +69,7 @@ async function main() {
     const privateKey3 = PrivateKey.generateED25519();
     const { accountId: accountId3 } = await (
         await new AccountCreateTransaction()
-            .setKey(privateKey3)
+            .setKeyWithoutAlias(privateKey3)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(0)
             .execute(client)
@@ -78,7 +78,7 @@ async function main() {
     const treasuryKey = PrivateKey.generateED25519();
     const { accountId: treasuryAccount } = await (
         await new AccountCreateTransaction()
-            .setKey(treasuryKey)
+            .setKeyWithAlias(treasuryKey)
             .setInitialBalance(new Hbar(10))
             .setMaxAutomaticTokenAssociations(-1)
             .execute(client)

--- a/examples/token-reject.js
+++ b/examples/token-reject.js
@@ -42,7 +42,7 @@ async function main() {
     const treasuryAccountId = (
         await (
             await new AccountCreateTransaction()
-                .setKey(treasuryPrivateKey)
+                .setKeyWithoutAlias(treasuryPrivateKey)
                 .setMaxAutomaticTokenAssociations(100)
                 .execute(client)
         ).getReceipt(client)
@@ -53,7 +53,7 @@ async function main() {
     const receiverAccountId = (
         await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey)
+                .setKeyWithoutAlias(receiverPrivateKey)
                 .setMaxAutomaticTokenAssociations(-1)
                 .execute(client)
         ).getReceipt(client)

--- a/examples/transfer-tokens.js
+++ b/examples/transfer-tokens.js
@@ -44,7 +44,7 @@ async function main() {
 
     try {
         let transaction = await new AccountCreateTransaction()
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .setInitialBalance(new Hbar(2))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);

--- a/examples/update-nfts-metadata-of-non-fungible-token.js
+++ b/examples/update-nfts-metadata-of-non-fungible-token.js
@@ -105,7 +105,7 @@ async function main() {
 
         // Create an account to transfer the NFT to
         const accountCreateTx = new AccountCreateTransaction()
-            .setKey(operatorKey)
+            .setKeyWithoutAlias(operatorKey)
             .setMaxAutomaticTokenAssociations(10)
             .setInitialBalance(new Hbar(100))
             .freezeWith(client);

--- a/examples/zeroTokenOperations.js
+++ b/examples/zeroTokenOperations.js
@@ -47,7 +47,7 @@ async function main() {
 
     try {
         let transaction = await new hashgraph.AccountCreateTransaction()
-            .setKey(alicePublicKey)
+            .setKeyWithoutAlias(alicePublicKey)
             .setInitialBalance(hashgraph.Hbar.fromString("10"))
             .freezeWithSigner(wallet);
         transaction = await transaction.signWithSigner(wallet);

--- a/tck/methods/account.ts
+++ b/tck/methods/account.ts
@@ -39,7 +39,7 @@ export const createAccount = async ({
     );
 
     if (key != null) {
-        transaction.setKey(getKeyFromString(key));
+        transaction.setKeyWithoutAlias(getKeyFromString(key));
     }
 
     if (initialBalance != null) {

--- a/test/integration/AccountCreateIntegrationTest.js
+++ b/test/integration/AccountCreateIntegrationTest.js
@@ -23,7 +23,7 @@ describe("AccountCreate", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -62,7 +62,7 @@ describe("AccountCreate", function () {
         const key = PrivateKey.generateECDSA();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -102,7 +102,7 @@ describe("AccountCreate", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .execute(env.client);
 
         const receipt = await response.getReceipt(env.client);
@@ -155,7 +155,7 @@ describe("AccountCreate", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .execute(env.client);
 
         const receipt = await response.getReceipt(env.client);
@@ -195,7 +195,7 @@ describe("AccountCreate", function () {
         const thresholdKey = new KeyList(publicKey, 1);
 
         let transaction = new AccountCreateTransaction()
-            .setKey(thresholdKey)
+            .setKeyWithoutAlias(thresholdKey)
             .setInitialBalance(Hbar.fromTinybars(1))
             .freezeWith(env.client);
 
@@ -218,6 +218,41 @@ describe("AccountCreate", function () {
         );
     });
 
+    it("should create account with no alias", async function () {
+        // Tests the third row of this table
+        // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
+
+        const adminKey = PrivateKey.generateECDSA();
+        const accountKey = PrivateKey.generateECDSA();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .execute(env.client);
+
+        let receipt = await (
+            await new AccountCreateTransaction()
+                .setKeyWithoutAlias(accountKey)
+                .freezeWith(env.client)
+                .execute(env.client)
+        ).getReceipt(env.client);
+
+        const accountId = receipt.accountId;
+
+        expect(accountId).to.not.be.null;
+
+        const info = await new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.not.be.null;
+        expect(
+            info.contractAccountId
+                .toString()
+                .startsWith("00000000000000000000"),
+        ).to.be.true;
+    });
+
     it("should create account with alias from admin key", async function () {
         // Tests the third row of this table
         // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
@@ -227,12 +262,12 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .execute(env.client);
 
         let receipt = await (
             await new AccountCreateTransaction()
-                .setKey(adminKey)
+                .setKeyWithoutAlias(adminKey)
                 .setAlias(evmAddress)
                 .freezeWith(env.client)
                 .execute(env.client)
@@ -253,6 +288,69 @@ describe("AccountCreate", function () {
         expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
     });
 
+    it("should create account with alias derived from ECDSA private admin key", async function () {
+        const adminKey = PrivateKey.generateECDSA();
+        const evmAddress = adminKey.publicKey.toEvmAddress();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        // create an account with alias derived from admin key
+        let receipt = await (
+            await new AccountCreateTransaction()
+                .setECDSAKeyWithAlias(adminKey)
+                .freezeWith(env.client)
+                .execute(env.client)
+        ).getReceipt(env.client);
+
+        const accountId = receipt.accountId;
+
+        expect(accountId).to.not.be.null;
+
+        const info = await new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.not.be.null;
+        expect(info.contractAccountId.toString()).to.be.equal(
+            evmAddress.toString(),
+        );
+        expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
+    });
+
+    it("should error when trying to create an account with alias derived from admin key when provided admin key is non-ECDSA private", async function () {
+        const adminKey = PrivateKey.generateED25519();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        let err = false;
+
+        try {
+            await (
+                await new AccountCreateTransaction()
+                    .setECDSAKeyWithAlias(adminKey)
+                    .freezeWith(env.client)
+                    .execute(env.client)
+            ).getReceipt(env.client);
+        } catch (error) {
+            err = error
+                .toString()
+                .includes(
+                    "'key' must be an ECDSA private key when 'aliasKey' is not provided.",
+                );
+        }
+        if (!err) {
+            throw new Error("account creation did not error");
+        }
+    });
+
     it("should create account with alias from admin key with receiver sig required", async function () {
         // Tests the fourth row of this table
         // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
@@ -262,7 +360,7 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -270,8 +368,47 @@ describe("AccountCreate", function () {
             await (
                 await new AccountCreateTransaction()
                     .setReceiverSignatureRequired(true)
-                    .setKey(adminKey)
+                    .setKeyWithoutAlias(adminKey)
                     .setAlias(evmAddress)
+                    .freezeWith(env.client)
+                    .sign(adminKey)
+            ).execute(env.client)
+        ).getReceipt(env.client);
+
+        const accountId = receipt.accountId;
+
+        expect(accountId).to.not.be.null;
+
+        const info = await new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.not.be.null;
+        expect(info.contractAccountId.toString()).to.be.equal(
+            evmAddress.toString(),
+        );
+        expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
+    });
+
+    it("should create account with alias derived from ECDSA private admin key with receiver sig required", async function () {
+        // Tests the fourth row of this table
+        // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
+
+        const adminKey = PrivateKey.generateECDSA();
+        const evmAddress = adminKey.publicKey.toEvmAddress();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        // create an account with alias derived from admin key
+        let receipt = await (
+            await (
+                await new AccountCreateTransaction()
+                    .setReceiverSignatureRequired(true)
+                    .setECDSAKeyWithAlias(adminKey)
                     .freezeWith(env.client)
                     .sign(adminKey)
             ).execute(env.client)
@@ -298,7 +435,7 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -307,8 +444,37 @@ describe("AccountCreate", function () {
             await (
                 await new AccountCreateTransaction()
                     .setReceiverSignatureRequired(true)
-                    .setKey(adminKey)
+                    .setKeyWithoutAlias(adminKey)
                     .setAlias(evmAddress)
+                    .freezeWith(env.client)
+                    .execute(env.client)
+            ).getReceipt(env.client);
+        } catch (error) {
+            err = error.toString().includes(Status.InvalidSignature.toString());
+        }
+
+        if (!err) {
+            throw new Error("account creation did not error");
+        }
+    });
+
+    it("should error when trying to create account with alias derived from ECDSA private admin key with receiver sig required without signature", async function () {
+        const adminKey = PrivateKey.generateECDSA();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        let err = false;
+
+        try {
+            // create an account with alias derived from admin key
+            await (
+                await new AccountCreateTransaction()
+                    .setReceiverSignatureRequired(true)
+                    .setECDSAKeyWithAlias(adminKey)
                     .freezeWith(env.client)
                     .execute(env.client)
             ).getReceipt(env.client);
@@ -329,7 +495,7 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -339,7 +505,7 @@ describe("AccountCreate", function () {
         let receipt = await (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(adminKey)
+                    .setKeyWithoutAlias(adminKey)
                     .setAlias(evmAddress)
                     .freezeWith(env.client)
                     .sign(key)
@@ -361,12 +527,83 @@ describe("AccountCreate", function () {
         expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
     });
 
+    it("should create account with admin key and alias derived from different ECDSA private alias key", async function () {
+        // Tests the fifth row of this table
+        // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
+
+        const adminKey = PrivateKey.generateED25519();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        const aliasKey = PrivateKey.generateECDSA();
+        const evmAddress = aliasKey.publicKey.toEvmAddress();
+
+        // create an account with alias derived from ECDSA private alias key
+        let receipt = await (
+            await (
+                await new AccountCreateTransaction()
+                    .setKeyWithAlias(adminKey, aliasKey)
+                    .freezeWith(env.client)
+                    .sign(aliasKey)
+            ).execute(env.client)
+        ).getReceipt(env.client);
+
+        const accountId = receipt.accountId;
+
+        expect(accountId).to.not.be.null;
+
+        const info = await new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.not.be.null;
+        expect(info.contractAccountId.toString()).to.be.equal(
+            evmAddress.toString(),
+        );
+        expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
+    });
+
+    it("should error when trying to create an account with alias derived from different alias key when provided alias key is non-ECDSA private", async function () {
+        const adminKey = PrivateKey.generateED25519();
+        const aliasKey = PrivateKey.generateED25519();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        let err = false;
+
+        try {
+            await (
+                await new AccountCreateTransaction()
+                    .setKeyWithAlias(adminKey, aliasKey)
+                    .freezeWith(env.client)
+                    .execute(env.client)
+            ).getReceipt(env.client);
+        } catch (error) {
+            err = error
+                .toString()
+                .includes(
+                    "'aliasKey' must be an ECDSA private key when provided.",
+                );
+        }
+        if (!err) {
+            throw new Error("account creation did not error");
+        }
+    });
+
     it("should error when trying to create account with alias different from admin key without signature", async function () {
         const adminKey = PrivateKey.generateED25519();
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -378,8 +615,36 @@ describe("AccountCreate", function () {
             await (
                 await new AccountCreateTransaction()
                     .setReceiverSignatureRequired(true)
-                    .setKey(adminKey)
+                    .setKeyWithoutAlias(adminKey)
                     .setAlias(evmAddress)
+                    .freezeWith(env.client)
+                    .execute(env.client)
+            ).getReceipt(env.client);
+        } catch (error) {
+            err = error.toString().includes(Status.InvalidSignature.toString());
+        }
+
+        if (!err) {
+            throw new Error("account creation did not error");
+        }
+    });
+
+    it("should error when trying to create account with admin key and alias derived from different ECDSA private alias key without signature", async function () {
+        const adminKey = PrivateKey.generateED25519();
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        const aliasKey = PrivateKey.generateECDSA();
+
+        let err = false;
+        try {
+            await (
+                await new AccountCreateTransaction()
+                    .setReceiverSignatureRequired(true)
+                    .setKeyWithAlias(adminKey, aliasKey)
                     .freezeWith(env.client)
                     .execute(env.client)
             ).getReceipt(env.client);
@@ -400,7 +665,7 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -412,10 +677,52 @@ describe("AccountCreate", function () {
                 await (
                     await new AccountCreateTransaction()
                         .setReceiverSignatureRequired(true)
-                        .setKey(adminKey)
+                        .setKeyWithoutAlias(adminKey)
                         .setAlias(evmAddress)
                         .freezeWith(env.client)
                         .sign(key)
+                ).sign(adminKey)
+            ).execute(env.client)
+        ).getReceipt(env.client);
+
+        const accountId = receipt.accountId;
+
+        expect(accountId).to.not.be.null;
+
+        const info = await new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.not.be.null;
+        expect(info.contractAccountId.toString()).to.be.equal(
+            evmAddress.toString(),
+        );
+        expect(info.key.toString()).to.be.equal(adminKey.publicKey.toString());
+    });
+
+    it("should create account with admin key and alias derived from ECDSA private alias key with receiver sig required", async function () {
+        // Tests the sixth row of this table
+        // https://github.com/hashgraph/hedera-improvement-proposal/blob/d39f740021d7da592524cffeaf1d749803798e9a/HIP/hip-583.md#signatures
+
+        const adminKey = PrivateKey.generateED25519();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        const aliasKey = PrivateKey.generateECDSA();
+        const evmAddress = aliasKey.publicKey.toEvmAddress();
+
+        let receipt = await (
+            await (
+                await (
+                    await new AccountCreateTransaction()
+                        .setReceiverSignatureRequired(true)
+                        .setKeyWithAlias(adminKey, aliasKey)
+                        .freezeWith(env.client)
+                        .sign(aliasKey)
                 ).sign(adminKey)
             ).execute(env.client)
         ).getReceipt(env.client);
@@ -440,7 +747,7 @@ describe("AccountCreate", function () {
 
         // create an admin account
         await new AccountCreateTransaction()
-            .setKey(adminKey)
+            .setKeyWithoutAlias(adminKey)
             .freezeWith(env.client)
             .execute(env.client);
 
@@ -453,10 +760,41 @@ describe("AccountCreate", function () {
                 await (
                     await new AccountCreateTransaction()
                         .setReceiverSignatureRequired(true)
-                        .setKey(adminKey)
+                        .setKeyWithoutAlias(adminKey)
                         .setAlias(evmAddress)
                         .freezeWith(env.client)
                         .sign(key)
+                ).execute(env.client)
+            ).getReceipt(env.client);
+        } catch (error) {
+            err = error.toString().includes(Status.InvalidSignature.toString());
+        }
+
+        if (!err) {
+            throw new Error("account creation did not error");
+        }
+    });
+
+    it("should error when trying to create account with admin key and alias derived from ECDSA private alias key and receiver sig required without signature", async function () {
+        const adminKey = PrivateKey.generateED25519();
+
+        // create an admin account
+        await new AccountCreateTransaction()
+            .setKeyWithoutAlias(adminKey)
+            .freezeWith(env.client)
+            .execute(env.client);
+
+        const aliasKey = PrivateKey.generateECDSA();
+
+        let err = false;
+        try {
+            await (
+                await (
+                    await new AccountCreateTransaction()
+                        .setReceiverSignatureRequired(true)
+                        .setKeyWithAlias(adminKey, aliasKey)
+                        .freezeWith(env.client)
+                        .sign(aliasKey)
                 ).execute(env.client)
             ).getReceipt(env.client);
         } catch (error) {

--- a/test/integration/AccountDeleteIntegrationTest.js
+++ b/test/integration/AccountDeleteIntegrationTest.js
@@ -21,7 +21,7 @@ describe("AccountDelete", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -61,7 +61,7 @@ describe("AccountDelete", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/AccountInfoIntegrationTest.js
+++ b/test/integration/AccountInfoIntegrationTest.js
@@ -32,7 +32,7 @@ describe("AccountInfo", function () {
 
         let createTransaction = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(10)) // 10 h
-            .setKey(newKey.publicKey)
+            .setKeyWithoutAlias(newKey.publicKey)
             .execute(env.client);
 
         const receiptCreateTransaction = await createTransaction.getReceipt(
@@ -70,7 +70,7 @@ describe("AccountInfo", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -115,7 +115,7 @@ describe("AccountInfo", function () {
 
         for (let i = 0; i < 300; i++) {
             response[i] = await new AccountCreateTransaction()
-                .setKey(key.publicKey)
+                .setKeyWithoutAlias(key.publicKey)
                 .setInitialBalance(new Hbar(2))
                 .execute(env.client);
         }

--- a/test/integration/AccountRecordsIntegrationTest.js
+++ b/test/integration/AccountRecordsIntegrationTest.js
@@ -21,7 +21,7 @@ describe("AccountRecords", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/AccountUpdateIntegrationTest.js
+++ b/test/integration/AccountUpdateIntegrationTest.js
@@ -26,7 +26,7 @@ describe("AccountUpdate", function () {
         const key2 = PrivateKey.generateED25519();
 
         let response = await new AccountCreateTransaction()
-            .setKey(key1.publicKey)
+            .setKeyWithoutAlias(key1.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -94,7 +94,7 @@ describe("AccountUpdate", function () {
         const key2 = PrivateKey.generateED25519();
 
         let response = await new AccountCreateTransaction()
-            .setKey(key1.publicKey)
+            .setKeyWithoutAlias(key1.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -146,7 +146,7 @@ describe("AccountUpdate", function () {
         const key2 = PrivateKey.generateED25519();
 
         let response = await new AccountCreateTransaction()
-            .setKey(key1.publicKey)
+            .setKeyWithoutAlias(key1.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -201,7 +201,7 @@ describe("AccountUpdate", function () {
         const key1 = PrivateKey.generateED25519();
 
         let response = await new AccountCreateTransaction()
-            .setKey(key1.publicKey)
+            .setKeyWithoutAlias(key1.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -236,7 +236,7 @@ describe("AccountUpdate", function () {
         const key2 = PrivateKey.generateED25519();
 
         let response = await new AccountCreateTransaction()
-            .setKey(key1.publicKey)
+            .setKeyWithoutAlias(key1.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/ClientIntegrationTest.js
+++ b/test/integration/ClientIntegrationTest.js
@@ -67,7 +67,7 @@ describe("ClientIntegration", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -109,7 +109,7 @@ describe("ClientIntegration", function () {
 
         const bytes = (
             await new AccountCreateTransaction()
-                .setKey(key.publicKey)
+                .setKeyWithoutAlias(key.publicKey)
                 .setInitialBalance(new Hbar(2))
                 .freezeWith(env.client)
                 .sign(key)

--- a/test/integration/CryptoTransferIntergationTest.js
+++ b/test/integration/CryptoTransferIntergationTest.js
@@ -21,7 +21,7 @@ describe("CryptoTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -54,7 +54,7 @@ describe("CryptoTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(0))
             .execute(env.client);
 

--- a/test/integration/CustomFeesIntegrationTest.js
+++ b/test/integration/CustomFeesIntegrationTest.js
@@ -302,7 +302,7 @@ describe("CustomFees", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -534,7 +534,7 @@ describe("CustomFees", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -629,7 +629,7 @@ describe("CustomFees", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -759,7 +759,7 @@ describe("CustomFees", function () {
         const accountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key.publicKey)
+                    .setKeyWithoutAlias(key.publicKey)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1008,7 +1008,7 @@ describe("CustomFees", function () {
         const account1 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -1017,7 +1017,7 @@ describe("CustomFees", function () {
         const account2 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -1157,7 +1157,7 @@ describe("CustomFees", function () {
         const account1 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1165,7 +1165,7 @@ describe("CustomFees", function () {
         const account2 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1173,7 +1173,7 @@ describe("CustomFees", function () {
         const account3 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1181,7 +1181,7 @@ describe("CustomFees", function () {
         const account4 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1189,7 +1189,7 @@ describe("CustomFees", function () {
         const account5 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1197,7 +1197,7 @@ describe("CustomFees", function () {
         const account6 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1205,7 +1205,7 @@ describe("CustomFees", function () {
         const account7 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1213,7 +1213,7 @@ describe("CustomFees", function () {
         const account8 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -1221,7 +1221,7 @@ describe("CustomFees", function () {
         const account9 = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;

--- a/test/integration/LiveHashIntegrationTest.js
+++ b/test/integration/LiveHashIntegrationTest.js
@@ -31,7 +31,7 @@ describe("LiveHash", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/MirrorNodeContractQuery.js
+++ b/test/integration/MirrorNodeContractQuery.js
@@ -140,7 +140,7 @@ describe("MirrorNodeContractQuery", function () {
 
         const { accountId } = await (
             await new AccountCreateTransaction()
-                .setKey(newOwnerKey)
+                .setKeyWithoutAlias(newOwnerKey)
                 .setInitialBalance(new Hbar(10))
                 .execute(env.client)
         ).getReceipt(env.client);

--- a/test/integration/NftAllowancesIntegrationTest.js
+++ b/test/integration/NftAllowancesIntegrationTest.js
@@ -29,7 +29,7 @@ describe("TokenNftAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -39,7 +39,7 @@ describe("TokenNftAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -111,7 +111,7 @@ describe("TokenNftAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -121,7 +121,7 @@ describe("TokenNftAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -240,7 +240,7 @@ describe("TokenNftAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -250,7 +250,7 @@ describe("TokenNftAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -374,7 +374,7 @@ describe("TokenNftAllowances", function () {
         const delegatingSpenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(delegatingSpenderKey)
+                    .setKeyWithoutAlias(delegatingSpenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -384,7 +384,7 @@ describe("TokenNftAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -394,7 +394,7 @@ describe("TokenNftAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)

--- a/test/integration/PrivateKey.js
+++ b/test/integration/PrivateKey.js
@@ -32,7 +32,7 @@ describe("PrivateKey signTransaction", function () {
         // Create account
         const createAccountTransaction = new AccountCreateTransaction()
             .setInitialBalance(new Hbar(2))
-            .setKey(keyList);
+            .setKeyWithoutAlias(keyList);
 
         const createResponse = await createAccountTransaction.execute(
             env.client,

--- a/test/integration/ScheduleCreateIntegrationTest.js
+++ b/test/integration/ScheduleCreateIntegrationTest.js
@@ -45,7 +45,7 @@ describe("ScheduleCreate", function () {
 
         const response = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(50))
-            .setKey(keyList)
+            .setKeyWithoutAlias(keyList)
             .execute(env.client);
 
         expect((await response.getReceipt(env.client)).accountId).to.be.not
@@ -129,7 +129,7 @@ describe("ScheduleCreate", function () {
 
         const response = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(10))
-            .setKey(keyList)
+            .setKeyWithoutAlias(keyList)
             .execute(env.client);
 
         expect((await response.getReceipt(env.client)).accountId).to.be.not
@@ -192,7 +192,7 @@ describe("ScheduleCreate", function () {
         const privateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(privateKey)
+                .setKeyWithoutAlias(privateKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -226,7 +226,7 @@ describe("ScheduleCreate", function () {
         const privateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(privateKey)
+                .setKeyWithoutAlias(privateKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -258,7 +258,7 @@ describe("ScheduleCreate", function () {
         const privateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(privateKey)
+                .setKeyWithoutAlias(privateKey)
                 .setInitialBalance(Hbar.from(1))
                 .execute(env.client)
         ).getReceipt(env.client);
@@ -315,7 +315,7 @@ describe("ScheduleCreate", function () {
 
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(keyList)
+                .setKeyWithoutAlias(keyList)
                 .setInitialBalance(Hbar.from(1))
                 .execute(env.client)
         ).getReceipt(env.client);
@@ -391,7 +391,7 @@ describe("ScheduleCreate", function () {
 
         const { accountId } = await (
             await new AccountCreateTransaction()
-                .setKey(keyList)
+                .setKeyWithoutAlias(keyList)
                 .setInitialBalance(new Hbar(10))
                 .execute(env.client)
         ).getReceipt(env.client);
@@ -484,7 +484,7 @@ describe("ScheduleCreate", function () {
 
         const { accountId } = await (
             await new AccountCreateTransaction()
-                .setKey(key)
+                .setKeyWithoutAlias(key)
                 .setInitialBalance(new Hbar(10))
                 .execute(env.client)
         ).getReceipt(env.client);

--- a/test/integration/TokenAirdropIntegrationTest.js
+++ b/test/integration/TokenAirdropIntegrationTest.js
@@ -58,7 +58,7 @@ describe("TokenAirdropIntegrationTest", function () {
 
         const receiverPrivateKey = PrivateKey.generateED25519();
         const accountCreateResponse = await new AccountCreateTransaction()
-            .setKey(receiverPrivateKey.publicKey)
+            .setKeyWithoutAlias(receiverPrivateKey.publicKey)
             .setMaxAutomaticTokenAssociations(-1)
             .execute(env.client);
 
@@ -132,7 +132,7 @@ describe("TokenAirdropIntegrationTest", function () {
 
         const receiverPrivateKey = PrivateKey.generateED25519();
         const accountCreateResponse = await new AccountCreateTransaction()
-            .setKey(receiverPrivateKey.publicKey)
+            .setKeyWithoutAlias(receiverPrivateKey.publicKey)
             .execute(env.client);
 
         const { accountId: receiverId } =
@@ -261,7 +261,7 @@ describe("TokenAirdropIntegrationTest", function () {
         const FEE_AMOUNT = 1;
         const receiverPrivateKey = PrivateKey.generateED25519();
         const createAccountResponse = await new AccountCreateTransaction()
-            .setKey(receiverPrivateKey.publicKey)
+            .setKeyWithoutAlias(receiverPrivateKey.publicKey)
             .setMaxAutomaticTokenAssociations(-1)
             .execute(env.client);
 
@@ -322,7 +322,7 @@ describe("TokenAirdropIntegrationTest", function () {
         const senderPrivateKey = PrivateKey.generateED25519();
         const { accountId: senderAccountId } = await (
             await new AccountCreateTransaction()
-                .setKey(senderPrivateKey.publicKey)
+                .setKeyWithoutAlias(senderPrivateKey.publicKey)
                 .setMaxAutomaticTokenAssociations(-1)
                 .setInitialBalance(new Hbar(10))
                 .execute(env.client)
@@ -452,7 +452,7 @@ describe("TokenAirdropIntegrationTest", function () {
         const receiverPublicKey = receiverPrivateKey.publicKey;
         const accountCreateResponse = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPublicKey)
+                .setKeyWithoutAlias(receiverPublicKey)
                 .setReceiverSignatureRequired(true)
                 .freezeWith(env.client)
                 .sign(receiverPrivateKey)

--- a/test/integration/TokenAllowancesIntegrationTest.js
+++ b/test/integration/TokenAllowancesIntegrationTest.js
@@ -33,7 +33,7 @@ describe("TokenAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -43,7 +43,7 @@ describe("TokenAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -100,7 +100,7 @@ describe("TokenAllowances", function () {
         const spenderAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(spenderKey)
+                    .setKeyWithoutAlias(spenderKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -110,7 +110,7 @@ describe("TokenAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -184,7 +184,7 @@ describe("TokenAllowances", function () {
         const receiverAccountId = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(receiverKey)
+                    .setKeyWithoutAlias(receiverKey)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)

--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -30,7 +30,7 @@ describe("TokenAssociate", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -138,7 +138,7 @@ describe("TokenAssociate", function () {
         beforeEach(async function () {
             receiverKey = PrivateKey.generateECDSA();
             const receiverAccountCreateTx = await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .freezeWith(env.client)
                 .sign(receiverKey);
             receiverId = (
@@ -600,7 +600,7 @@ describe("TokenAssociate", function () {
                 const spenderKey = PrivateKey.generateECDSA();
                 const spenderAccountCreateTx =
                     await new AccountCreateTransaction()
-                        .setKey(spenderKey)
+                        .setKeyWithoutAlias(spenderKey)
                         .setMaxAutomaticTokenAssociations(-1)
                         .setInitialBalance(new Hbar(1))
                         .execute(env.client);
@@ -702,7 +702,7 @@ describe("TokenAssociate", function () {
 
                 const spenderAccountCreateTx =
                     await new AccountCreateTransaction()
-                        .setKey(spenderKey)
+                        .setKeyWithoutAlias(spenderKey)
                         .setInitialBalance(new Hbar(1))
                         .setMaxAutomaticTokenAssociations(-1)
                         .execute(env.client);
@@ -802,7 +802,7 @@ describe("TokenAssociate", function () {
                 const receiverKey = PrivateKey.generateECDSA();
                 const receiverAccountResponse =
                     await new AccountCreateTransaction()
-                        .setKey(receiverKey)
+                        .setKeyWithoutAlias(receiverKey)
                         .setMaxAutomaticTokenAssociations(-1)
                         .setInitialBalance(new Hbar(1))
                         .execute(env.client);
@@ -866,7 +866,7 @@ describe("TokenAssociate", function () {
                     const key = PrivateKey.generateECDSA();
                     const accountCreateInvalidAutoAssociation =
                         await new AccountCreateTransaction()
-                            .setKey(key)
+                            .setKeyWithoutAlias(key)
                             .setMaxAutomaticTokenAssociations(-2)
                             .execute(env.client);
 

--- a/test/integration/TokenCancelAirdropTransaction.js
+++ b/test/integration/TokenCancelAirdropTransaction.js
@@ -54,7 +54,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -113,7 +113,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -170,7 +170,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -216,7 +216,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -292,14 +292,14 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverPrivateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey)
+                .setKeyWithoutAlias(receiverPrivateKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
         const receiverPrivateKey2 = PrivateKey.generateED25519();
         const { accountId: receiverId2 } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey2)
+                .setKeyWithoutAlias(receiverPrivateKey2)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -377,7 +377,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -426,7 +426,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -440,7 +440,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const randomAccountKey = PrivateKey.generateED25519();
         const { accountId: randomAccountId } = await (
             await new AccountCreateTransaction()
-                .setKey(randomAccountKey)
+                .setKeyWithoutAlias(randomAccountKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -490,7 +490,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -545,7 +545,7 @@ describe("TokenCancelAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 

--- a/test/integration/TokenClaimAirdropTransaction.js
+++ b/test/integration/TokenClaimAirdropTransaction.js
@@ -59,7 +59,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverPrivateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey)
+                .setKeyWithoutAlias(receiverPrivateKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -149,14 +149,14 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverPrivateKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey)
+                .setKeyWithoutAlias(receiverPrivateKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
         const receiverPrivateKey2 = PrivateKey.generateED25519();
         const { accountId: receiverId2 } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey2)
+                .setKeyWithoutAlias(receiverPrivateKey2)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -255,7 +255,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -314,7 +314,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -328,7 +328,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const randomAccountKey = PrivateKey.generateED25519();
         const { accountId: randomAccountId } = await (
             await new AccountCreateTransaction()
-                .setKey(randomAccountKey)
+                .setKeyWithoutAlias(randomAccountKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -377,7 +377,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -438,7 +438,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -483,7 +483,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -522,7 +522,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 
@@ -555,7 +555,7 @@ describe("TokenClaimAirdropIntegrationTest", function () {
         const receiverKey = PrivateKey.generateED25519();
         const { accountId: receiverId } = await (
             await new AccountCreateTransaction()
-                .setKey(receiverKey)
+                .setKeyWithoutAlias(receiverKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 

--- a/test/integration/TokenDissociateIntegrationTest.js
+++ b/test/integration/TokenDissociateIntegrationTest.js
@@ -29,7 +29,7 @@ describe("TokenDissociate", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -158,7 +158,7 @@ describe("TokenDissociate", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key.publicKey)
+                    .setKeyWithoutAlias(key.publicKey)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;

--- a/test/integration/TokenFreezeIntegrationTest.js
+++ b/test/integration/TokenFreezeIntegrationTest.js
@@ -23,7 +23,7 @@ describe("TokenFreeze", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -84,7 +84,7 @@ describe("TokenFreeze", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/TokenGrantKycIntegrationTest.js
+++ b/test/integration/TokenGrantKycIntegrationTest.js
@@ -23,7 +23,7 @@ describe("TokenGrantKyc", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -84,7 +84,7 @@ describe("TokenGrantKyc", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/TokenNftIntegrationTest.js
+++ b/test/integration/TokenNftIntegrationTest.js
@@ -29,7 +29,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -126,7 +126,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -194,7 +194,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -290,7 +290,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -462,7 +462,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -532,7 +532,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -594,7 +594,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)
@@ -705,7 +705,7 @@ describe("TokenNft", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key)
+                    .setKeyWithoutAlias(key)
                     .setInitialBalance(new Hbar(2))
                     .execute(env.client)
             ).getReceipt(env.client)

--- a/test/integration/TokenRejectFlowIntegrationTest.js
+++ b/test/integration/TokenRejectFlowIntegrationTest.js
@@ -50,7 +50,7 @@ describe("TokenRejectIntegrationTest", function () {
         // create receiver account
         let receiverPrivateKey = await PrivateKey.generateECDSA();
         const receiverCreateAccount = await new AccountCreateTransaction()
-            .setKey(receiverPrivateKey)
+            .setKeyWithoutAlias(receiverPrivateKey)
             .setInitialBalance(new Hbar(1))
             .execute(env.client);
 
@@ -137,7 +137,7 @@ describe("TokenRejectIntegrationTest", function () {
         // create receiver account
         let receiverPrivateKey = await PrivateKey.generateECDSA();
         const receiverCreateAccount = await new AccountCreateTransaction()
-            .setKey(receiverPrivateKey)
+            .setKeyWithoutAlias(receiverPrivateKey)
             .setInitialBalance(new Hbar(1))
             .execute(env.client);
 

--- a/test/integration/TokenRejectIntegrationTest.js
+++ b/test/integration/TokenRejectIntegrationTest.js
@@ -45,7 +45,7 @@ describe("TokenRejectIntegrationTest", function () {
             // create receiver account
             receiverPrivateKey = await PrivateKey.generateECDSA();
             const receiverCreateAccount = await new AccountCreateTransaction()
-                .setKey(receiverPrivateKey)
+                .setKeyWithoutAlias(receiverPrivateKey)
                 .setInitialBalance(new Hbar(1))
                 .setMaxAutomaticTokenAssociations(-1)
                 .execute(env.client);
@@ -170,7 +170,7 @@ describe("TokenRejectIntegrationTest", function () {
             const spenderAccountResponse = await new AccountCreateTransaction()
                 .setMaxAutomaticTokenAssociations(-1)
                 .setInitialBalance(new Hbar(10))
-                .setKey(spenderAccountPrivateKey)
+                .setKeyWithoutAlias(spenderAccountPrivateKey)
                 .execute(env.client);
 
             const { accountId: spenderAccountId } =
@@ -341,7 +341,7 @@ describe("TokenRejectIntegrationTest", function () {
                 const receiverPrivateKey = PrivateKey.generateED25519();
                 const { accountId: emptyBalanceUserId } = await (
                     await new AccountCreateTransaction()
-                        .setKey(receiverPrivateKey)
+                        .setKeyWithoutAlias(receiverPrivateKey)
                         .setMaxAutomaticTokenAssociations(-1)
                         .execute(env.client)
                 ).getReceipt(env.client);
@@ -440,7 +440,7 @@ describe("TokenRejectIntegrationTest", function () {
             receiverId = (
                 await (
                     await new AccountCreateTransaction()
-                        .setKey(receiverPrivateKey)
+                        .setKeyWithoutAlias(receiverPrivateKey)
                         .setMaxAutomaticTokenAssociations(-1)
                         .execute(env.client)
                 ).getReceipt(env.client)
@@ -573,7 +573,7 @@ describe("TokenRejectIntegrationTest", function () {
             const spenderAccountResponse = await new AccountCreateTransaction()
                 .setMaxAutomaticTokenAssociations(-1)
                 .setInitialBalance(new Hbar(10))
-                .setKey(spenderAccountPrivateKey)
+                .setKeyWithoutAlias(spenderAccountPrivateKey)
                 .execute(env.client);
 
             const { accountId: spenderAccountId } =
@@ -807,7 +807,7 @@ describe("TokenRejectIntegrationTest", function () {
                 const wrongOwnerPrivateKey = PrivateKey.generateED25519();
                 const { accountId: wrongOwnerId } = await (
                     await new AccountCreateTransaction()
-                        .setKey(wrongOwnerPrivateKey)
+                        .setKeyWithoutAlias(wrongOwnerPrivateKey)
                         .setMaxAutomaticTokenAssociations(-1)
                         .execute(env.client)
                 ).getReceipt(env.client);
@@ -860,7 +860,7 @@ describe("TokenRejectIntegrationTest", function () {
             receiverPrivateKey = await PrivateKey.generateECDSA();
             const receiverCreateAccountResponse =
                 await new AccountCreateTransaction()
-                    .setKey(receiverPrivateKey)
+                    .setKeyWithoutAlias(receiverPrivateKey)
                     .setInitialBalance(new Hbar(1))
                     .setMaxAutomaticTokenAssociations(-1)
                     .execute(env.client);

--- a/test/integration/TokenRevokeKycIntegrationTest.js
+++ b/test/integration/TokenRevokeKycIntegrationTest.js
@@ -24,7 +24,7 @@ describe("TokenRevokeKyc", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -107,7 +107,7 @@ describe("TokenRevokeKyc", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/TokenTransferIntegrationTest.js
+++ b/test/integration/TokenTransferIntegrationTest.js
@@ -29,7 +29,7 @@ describe("TokenTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -98,7 +98,7 @@ describe("TokenTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -169,7 +169,7 @@ describe("TokenTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -240,7 +240,7 @@ describe("TokenTransfer", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key.publicKey)
+                    .setKeyWithoutAlias(key.publicKey)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;
@@ -319,7 +319,7 @@ describe("TokenTransfer", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .setMaxAutomaticTokenAssociations(10)
             .execute(env.client);

--- a/test/integration/TokenUnfreezeIntegrationTest.js
+++ b/test/integration/TokenUnfreezeIntegrationTest.js
@@ -24,7 +24,7 @@ describe("TokenUnfreeze", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -107,7 +107,7 @@ describe("TokenUnfreeze", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/TokenUpdateIntegrationTest.js
+++ b/test/integration/TokenUpdateIntegrationTest.js
@@ -149,7 +149,7 @@ describe("TokenUpdate", function () {
             await (
                 await (
                     await new AccountCreateTransaction()
-                        .setKey(key5)
+                        .setKeyWithoutAlias(key5)
                         .freezeWith(env.client)
                         .sign(key5)
                 ).execute(env.client)
@@ -368,7 +368,7 @@ describe("TokenUpdate", function () {
         const account = (
             await (
                 await new AccountCreateTransaction()
-                    .setKey(key.publicKey)
+                    .setKeyWithoutAlias(key.publicKey)
                     .execute(env.client)
             ).getReceipt(env.client)
         ).accountId;

--- a/test/integration/TokenWipeIntegrationTest.js
+++ b/test/integration/TokenWipeIntegrationTest.js
@@ -27,7 +27,7 @@ describe("TokenWipe", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -115,7 +115,7 @@ describe("TokenWipe", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -186,7 +186,7 @@ describe("TokenWipe", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 
@@ -254,7 +254,7 @@ describe("TokenWipe", function () {
         const key = PrivateKey.generateED25519();
 
         const response = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setInitialBalance(new Hbar(2))
             .execute(env.client);
 

--- a/test/integration/TransactionIntegrationTest.js
+++ b/test/integration/TransactionIntegrationTest.js
@@ -30,7 +30,7 @@ describe("TransactionIntegration", function () {
         const key = PrivateKey.generateED25519();
 
         const transaction = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .freezeWith(env.client)
             .signWithOperator(env.client);
 
@@ -772,7 +772,7 @@ describe("TransactionIntegration", function () {
             // Create account
             const createAccountTransaction = new AccountCreateTransaction()
                 .setInitialBalance(new Hbar(2))
-                .setKey(keyList);
+                .setKeyWithoutAlias(keyList);
 
             const createResponse = await createAccountTransaction.execute(
                 env.client,

--- a/test/integration/TransactionReceiptIntegrationTest.js
+++ b/test/integration/TransactionReceiptIntegrationTest.js
@@ -36,7 +36,7 @@ describe("TransactionReceipt", function () {
 
         const response = await new AccountCreateTransaction()
             .setInitialBalance(new Hbar(50))
-            .setKey(keyList)
+            .setKeyWithoutAlias(keyList)
             .execute(env.client);
 
         expect((await response.getReceipt(env.client)).accountId).to.be.not

--- a/test/integration/TransactionResponseTest.js
+++ b/test/integration/TransactionResponseTest.js
@@ -20,7 +20,7 @@ describe("TransactionResponse", function () {
         const key = PrivateKey.generateED25519();
 
         const transaction = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .execute(env.client);
 
         const record = await transaction.getRecord(env.client);
@@ -50,7 +50,7 @@ describe("TransactionResponse", function () {
         const key = PrivateKey.generateED25519();
 
         const transaction = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .execute(env.client);
 
         const transactionReceiptQuery = transaction.getReceiptQuery();
@@ -79,7 +79,7 @@ describe("TransactionResponse", function () {
         const key = PrivateKey.generateED25519();
 
         const transaction = await new AccountCreateTransaction()
-            .setKey(key.publicKey)
+            .setKeyWithoutAlias(key.publicKey)
             .execute(env.client);
 
         const transactionRecordQuery = transaction.getRecordQuery();
@@ -109,7 +109,7 @@ describe("TransactionResponse", function () {
 
         const receipt = await (
             await new AccountCreateTransaction()
-                .setKey(key.publicKey)
+                .setKeyWithoutAlias(key.publicKey)
                 .execute(env.client)
         ).getReceipt(env.client);
 

--- a/test/integration/WalletIntegrationTest.js
+++ b/test/integration/WalletIntegrationTest.js
@@ -29,7 +29,7 @@ describe("WalletIntegration", function () {
 
         // Create account id for the signer
         let createTransaction = await new AccountCreateTransaction()
-            .setKey(signerKey)
+            .setKeyWithoutAlias(signerKey)
             .setInitialBalance(new Hbar(5))
             .signWithOperator(env.client);
 

--- a/test/integration/client/BaseIntegrationTestEnv.js
+++ b/test/integration/client/BaseIntegrationTestEnv.js
@@ -128,7 +128,7 @@ export default class BaseIntegrationTestEnv {
         const newOperatorKey = PrivateKey.generateECDSA();
 
         const response = await new AccountCreateTransaction()
-            .setKey(newOperatorKey)
+            .setKeyWithoutAlias(newOperatorKey)
             .setInitialBalance(
                 new Hbar(options.balance != null ? options.balance : 100),
             )

--- a/test/unit/AccountCreateTransaction.js
+++ b/test/unit/AccountCreateTransaction.js
@@ -13,6 +13,154 @@ import {
 } from "../../src/index.js";
 
 describe("AccountCreateTransaction", function () {
+    describe("setECDSAKeyWithAlias", function () {
+        /** @type {PrivateKey} */
+        let privateEcdsaAccountKey;
+
+        beforeEach(function () {
+            privateEcdsaAccountKey = PrivateKey.generateECDSA();
+        });
+
+        it("should throw when transaction is frozen", function () {
+            const transaction = new AccountCreateTransaction()
+                .setNodeAccountIds([new AccountId(3)])
+                .setTransactionId(TransactionId.generate(new AccountId(3)));
+
+            transaction.freeze();
+
+            expect(() => {
+                transaction.setECDSAKeyWithAlias(privateEcdsaAccountKey);
+            }).to.throw(Error);
+        });
+
+        it("should throw when a non-private ECDSA key is provided", function () {
+            const publicAccountKey = PrivateKey.generateECDSA().publicKey;
+
+            expect(() => {
+                new AccountCreateTransaction().setECDSAKeyWithAlias(
+                    publicAccountKey,
+                );
+            }).to.throw(Error);
+        });
+
+        it("should throw when a non-ECDSA private key is provided", function () {
+            const privateEd25519AccountKey = PrivateKey.generateED25519();
+
+            expect(() => {
+                new AccountCreateTransaction().setECDSAKeyWithAlias(
+                    privateEd25519AccountKey,
+                );
+            }).to.throw(Error);
+        });
+
+        it("should set correct account key and derived alias", function () {
+            const transaction =
+                new AccountCreateTransaction().setECDSAKeyWithAlias(
+                    privateEcdsaAccountKey,
+                );
+
+            expect(transaction.key.toString()).to.equal(
+                privateEcdsaAccountKey.toString(),
+            );
+
+            expect(transaction.alias.toString()).to.equal(
+                privateEcdsaAccountKey.publicKey.toEvmAddress(),
+            );
+        });
+    });
+
+    describe("setKeyWithAlias", function () {
+        /** @type {Key} */
+        let accountKey;
+
+        /** @type {PrivateKey} */
+        let privateEcdsaAliasKey;
+
+        beforeEach(function () {
+            accountKey = PrivateKey.generateECDSA().publicKey;
+            privateEcdsaAliasKey = PrivateKey.generateECDSA();
+        });
+
+        it("should throw when transaction is frozen", function () {
+            const transaction = new AccountCreateTransaction()
+                .setNodeAccountIds([new AccountId(3)])
+                .setTransactionId(TransactionId.generate(new AccountId(3)));
+
+            transaction.freeze();
+
+            expect(() => {
+                transaction.setKeyWithAlias(accountKey, privateEcdsaAliasKey);
+            }).to.throw(Error);
+        });
+
+        it("should throw when a non-private alias key is provided", function () {
+            const nonPrivateAliasKey = PrivateKey.generateECDSA().publicKey;
+
+            expect(() => {
+                new AccountCreateTransaction().setKeyWithAlias(
+                    accountKey,
+                    nonPrivateAliasKey,
+                );
+            }).to.throw(Error);
+        });
+
+        it("when a non-ECDSA private aliasKey is provided should throw", function () {
+            const nonPrivateEcdsaAliasKey = PrivateKey.generateED25519();
+
+            expect(() => {
+                new AccountCreateTransaction().setKeyWithAlias(
+                    accountKey,
+                    nonPrivateEcdsaAliasKey,
+                );
+            }).to.throw(Error);
+        });
+
+        it("should set correct account key and alias derived from the alias key", function () {
+            const transaction = new AccountCreateTransaction().setKeyWithAlias(
+                accountKey,
+                privateEcdsaAliasKey,
+            );
+
+            expect(transaction.key.toString()).to.equal(accountKey.toString());
+
+            expect(transaction.alias.toString()).to.equal(
+                privateEcdsaAliasKey.publicKey.toEvmAddress(),
+            );
+        });
+    });
+
+    describe("setKeyWithoutAlias", function () {
+        it("should throw when transaction is frozen", function () {
+            const transaction = new AccountCreateTransaction()
+                .setNodeAccountIds([new AccountId(3)])
+                .setTransactionId(TransactionId.generate(new AccountId(3)));
+
+            transaction.freeze();
+
+            const accountKey = PrivateKey.generateECDSA();
+            expect(() => {
+                transaction.setKeyWithoutAlias(accountKey);
+            }).to.throw(Error);
+        });
+
+        it("should set correct account key without modifying the alias when key is provided", function () {
+            const accountKey = PrivateKey.generateECDSA();
+            const aliasKey = PrivateKey.generateECDSA();
+
+            const transaction = new AccountCreateTransaction().setAlias(
+                aliasKey.publicKey.toEvmAddress(),
+            );
+
+            transaction.setKeyWithoutAlias(accountKey);
+
+            expect(transaction.key.toString()).to.equal(accountKey.toString());
+
+            expect(transaction.alias.toString()).to.equal(
+                aliasKey.publicKey.toEvmAddress(),
+            );
+        });
+    });
+
     it("should round trip from bytes and maintain order", function () {
         const key1 = PrivateKey.generateECDSA();
         const spenderAccountId1 = new AccountId(7);

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -31,7 +31,7 @@ describe("Transaction", function () {
             "0adb012ad8010a6e0a130a0608ab0b10ce0412070800100018ec0718001206080010001803188084af5f2202087832005a440a2212206e0433faf04e8a674a114ed04d27bd43b0549a2ed69c9709a5a2058922c0cc4830ffffffffffffffff7f38ffffffffffffffff7f40004a050880ceda0388010012660a640a206e0433faf04e8a674a114ed04d27bd43b0549a2ed69c9709a5a2058922c0cc481a406f7b1823defed495205f67504243abd623bef1eb9dc4053b879b5e25fff382814172d0676464a6a5b7adfc7968ae8af236ac91fd751d632c0412b5f77431930d0adb012ad8010a6e0a130a0608ab0b10ce0412070800100018ec0718001206080010001804188084af5f2202087832005a440a2212206e0433faf04e8a674a114ed04d27bd43b0549a2ed69c9709a5a2058922c0cc4830ffffffffffffffff7f38ffffffffffffffff7f40004a050880ceda0388010012660a640a206e0433faf04e8a674a114ed04d27bd43b0549a2ed69c9709a5a2058922c0cc481a408d3fb2b8da90457cc447771361b0e27f784b70664604a5490a135595a69f2bbf2fd725a703174999d25f6f295cd58f116210dffefb94703c34fc8107be0a7908";
 
         const transaction = await new AccountCreateTransaction()
-            .setKey(key)
+            .setKeyWithoutAlias(key)
             .setNodeAccountIds([new AccountId(3), new AccountId(4)])
             .setTransactionId(transactionId)
             .freeze()
@@ -329,7 +329,7 @@ describe("Transaction", function () {
             txId = TransactionId.generate(nodeAccountIds[0]);
 
             transaction = new AccountCreateTransaction()
-                .setKey(account.publicKey)
+                .setKeyWithoutAlias(account.publicKey)
                 .setNodeAccountIds(nodeAccountIds)
                 .setTransactionId(txId)
                 .freeze();


### PR DESCRIPTION
Description:
This PR extends the AccountCreateTransaction with the following APIs:

- **setECDSAKeyWithAlias(ECDSAKey)** - Sets ECDSA private key, derives and sets it's EVM address in the background.
- **setKeyWithAlias(Key, ECDSAKey)** - Allows for setting the account key and a separate ECDSA private key that the EVM address should be derived from. A user must sign the transaction with both keys for this flow to be successful.
- **setKeyWithoutAlias(Key)** - Explicitly calls out that the alias is not set.

### 🚨 Deprecation Notice:
- **`setKey(Key)`** is now **deprecated** in favor of `setKeyWithoutAlias`.

Related issue(s):
https://github.com/hiero-ledger/hiero-sdk-js/issues/2795

## ✅ Checklist:
- [x] **Extended the APIs** of `AccountCreateTransaction`
- [x] **Deprecated** `setKey(Key)` API of `AccountCreateTransaction`
- [x] **Tested** (unit, integration, etc.)
- [x] **Replaced deprecated API (`setKey(Key)`)** occurences with the new relevant one (`setKeyWithoutAlias(Key)`)
- [x]  **Add examples**