### PR TITLE
fix: Changed Protobufs submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "packages/proto/src/services"]
 	path = packages/proto/src/services
 	url = https://github.com/hiero-ledger/hiero-consensus-node.git
-s

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "packages/proto/src/services"]
 	path = packages/proto/src/services
-	url = https://github.com/hashgraph/hedera-services.git
+	url = https://github.com/hiero-ledger/hiero-consensus-node.git
+s


### PR DESCRIPTION
Description:
This PR changes Protobufs submodule path to the new location of the repository - [Hiero](https://github.com/hiero-ledger/hiero-consensus-node/)

Related issue(s):
#2871  

Checklist
- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)