### PR TITLE
fix(ecsda): return ecdsa signature with a normalized s value

### DIFF
--- a/packages/cryptography/src/primitive/ecdsa.js
+++ b/packages/cryptography/src/primitive/ecdsa.js
@@ -63,7 +63,14 @@ export function sign(keydata, message) {
     const msg = hex.encode(message);
     const data = hex.decode(keccak256(`0x${msg}`));
     const keypair = secp256k1.keyFromPrivate(keydata);
-    const signature = keypair.sign(data);
+    const signature = keypair.sign(data, {
+        // the elliptic library generates a non-normalized s value by-default
+        // this seems to be legacy behavior that they are loathe to change 
+        // as its pretty silent if someone was depending on it
+        // most every other client I can normalizes the s value, passing `true`
+        // here will return a normalized s value
+        canonical: true,
+    });
 
     const r = signature.r.toArray("be", 32);
     const s = signature.s.toArray("be", 32);


### PR DESCRIPTION
An ECDSA _message_ signature generated by the JS SDK does not verify in the Rust SDK.

---

When exploring signing a message with `PrivateKey` in the JS SDK and verifying it with the Rust SDK, I noticed that the JS SDK does not return a normalized `s` value in the ECDSA signature. 

This is **not** a breaking change as the underlying `elliptic` library validates both normalized and non-normalized signatures but other SDKs only validate normalized signatures.

It is documented here - https://github.com/indutny/elliptic/wiki - that we need to use `canonical: true` to be Crypto-compatible.