### PR TITLE
fix: zero assumed shard and realm

### DIFF
--- a/src/Wallet.js
+++ b/src/Wallet.js
@@ -65,6 +65,7 @@ export default class Wallet {
 
     /**
      * @returns {Promise<Wallet>}
+     * @deprecated
      */
     static createRandomED25519() {
         const privateKey = PrivateKey.generateED25519();
@@ -75,6 +76,7 @@ export default class Wallet {
 
     /**
      * @returns {Promise<Wallet>}
+     * @deprecated
      */
     static createRandomECDSA() {
         const privateKey = PrivateKey.generateECDSA();

--- a/src/account/AccountAllowanceAdjustTransaction.js
+++ b/src/account/AccountAllowanceAdjustTransaction.js
@@ -105,8 +105,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,
@@ -115,8 +115,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                         ? AccountId.fromString(ownerAccountId)
                         : ownerAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                ownerAccountId.shard,
+                                ownerAccountId.realm,
                                 ownerAccountId.toSolidityAddress(),
                             )
                           : ownerAccountId,
@@ -203,8 +203,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,
@@ -213,8 +213,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                         ? AccountId.fromString(ownerAccountId)
                         : ownerAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                ownerAccountId.shard,
+                                ownerAccountId.realm,
                                 ownerAccountId.toSolidityAddress(),
                             )
                           : ownerAccountId,
@@ -287,8 +287,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                 ? AccountId.fromString(spenderAccountId)
                 : spenderAccountId instanceof ContractId
                   ? AccountId.fromEvmAddress(
-                        0,
-                        0,
+                        spenderAccountId.shard,
+                        spenderAccountId.realm,
                         spenderAccountId.toSolidityAddress(),
                     )
                   : spenderAccountId;
@@ -297,8 +297,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                 ? AccountId.fromString(ownerAccountId)
                 : ownerAccountId instanceof ContractId
                   ? AccountId.fromEvmAddress(
-                        0,
-                        0,
+                        ownerAccountId.shard,
+                        ownerAccountId.realm,
                         ownerAccountId.toSolidityAddress(),
                     )
                   : ownerAccountId;
@@ -453,8 +453,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                             ? AccountId.fromString(ownerAccountId)
                             : ownerAccountId instanceof ContractId
                               ? AccountId.fromEvmAddress(
-                                    0,
-                                    0,
+                                    ownerAccountId.shard,
+                                    ownerAccountId.realm,
                                     ownerAccountId.toSolidityAddress(),
                                 )
                               : ownerAccountId
@@ -464,8 +464,8 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,

--- a/src/account/AccountAllowanceApproveTransaction.js
+++ b/src/account/AccountAllowanceApproveTransaction.js
@@ -136,8 +136,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,
@@ -146,8 +146,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(ownerAccountId)
                         : ownerAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                ownerAccountId.shard,
+                                ownerAccountId.realm,
                                 ownerAccountId.toSolidityAddress(),
                             )
                           : ownerAccountId,
@@ -209,8 +209,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,
@@ -219,8 +219,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(ownerAccountId)
                         : ownerAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                ownerAccountId.shard,
+                                ownerAccountId.realm,
                                 ownerAccountId.toSolidityAddress(),
                             )
                           : ownerAccountId,
@@ -308,8 +308,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                 ? AccountId.fromString(spenderAccountId)
                 : spenderAccountId instanceof ContractId
                   ? AccountId.fromEvmAddress(
-                        0,
-                        0,
+                        spenderAccountId.shard,
+                        spenderAccountId.realm,
                         spenderAccountId.toSolidityAddress(),
                     )
                   : spenderAccountId;
@@ -339,8 +339,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                             ? AccountId.fromString(ownerAccountId)
                             : ownerAccountId instanceof ContractId
                               ? AccountId.fromEvmAddress(
-                                    0,
-                                    0,
+                                    ownerAccountId.shard,
+                                    ownerAccountId.realm,
                                     ownerAccountId.toSolidityAddress(),
                                 )
                               : ownerAccountId,
@@ -419,8 +419,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(spenderAccountId)
                         : spenderAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                spenderAccountId.shard,
+                                spenderAccountId.realm,
                                 spenderAccountId.toSolidityAddress(),
                             )
                           : spenderAccountId,
@@ -429,8 +429,8 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
                         ? AccountId.fromString(ownerAccountId)
                         : ownerAccountId instanceof ContractId
                           ? AccountId.fromEvmAddress(
-                                0,
-                                0,
+                                ownerAccountId.shard,
+                                ownerAccountId.realm,
                                 ownerAccountId.toSolidityAddress(),
                             )
                           : ownerAccountId,

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -96,10 +96,10 @@ export default class AccountId {
                 ? EvmAddress.fromString(evmAddress)
                 : evmAddress;
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         if (isLongZeroAddress(evmAddressObj.toBytes())) {
-            // eslint-disable-next-line deprecation/deprecation
-            return this.fromSolidityAddress(evmAddressObj.toString());
+            return new AccountId(
+                ...entity_id.fromSolidityAddress(evmAddressObj.toString()),
+            );
         } else {
             return new AccountId(shard, realm, 0, undefined, evmAddressObj);
         }

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -51,7 +51,6 @@ export default class ContractId extends Key {
      * @returns {ContractId}
      */
     static fromEvmAddress(shard, realm, evmAddress) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         if (isLongZeroAddress(hex.decode(evmAddress))) {
             return new ContractId(...entity_id.fromSolidityAddress(evmAddress));
         } else {


### PR DESCRIPTION
### Description:
This change ensures handling of different shard and realm configurations in places where it was hardcoded as `0`

Fixes: #2880