### PR TITLE
fix: ECDSA private key

### DIFF
--- a/packages/cryptography/src/EcdsaPrivateKey.js
+++ b/packages/cryptography/src/EcdsaPrivateKey.js
@@ -181,8 +181,10 @@ export default class EcdsaPrivateKey {
      * @returns {Uint8Array}
      */
     toBytesRaw() {
+        const privateKey = this._keyPair.privateKey.subarray(-32); // Takes the last 32 bytes (or fewer if shorter)
+        const leadingZeroes = 32 - privateKey.length;
         const bytes = new Uint8Array(32);
-        bytes.set(this._keyPair.privateKey.slice(0, 32), 0);
+        bytes.set(privateKey, leadingZeroes);
         return bytes;
     }
 }

--- a/test/unit/PrivateKey.js
+++ b/test/unit/PrivateKey.js
@@ -24,6 +24,21 @@ describe("PrivateKey signTransaction", function () {
             .freeze();
     });
 
+    it("should add zeroes at the beginning of <32 bytes private key", async function () {
+        const EXPECTED_PRIVATE_KEY =
+            "0000000000000000fd2fe3d732d3412140accab21b4b7303ff05f9c9127542cd";
+        const derPrefix = "3030020100300706052b8104000a04220420";
+        const EXPECTED_DER_PRIVATE_KEY = derPrefix + EXPECTED_PRIVATE_KEY;
+
+        const SHORT_PRIVATE_KEY =
+            PrivateKey.fromStringECDSA(EXPECTED_PRIVATE_KEY);
+
+        expect(SHORT_PRIVATE_KEY.toStringRaw()).to.equal(EXPECTED_PRIVATE_KEY);
+        expect(SHORT_PRIVATE_KEY.toStringDer()).to.equal(
+            EXPECTED_DER_PRIVATE_KEY,
+        );
+    });
+
     it("should sign transaction and add signature", function () {
         const { bodyBytes } = transaction._signedTransactions.list[0];
         const sig = privateKey.sign(bodyBytes);


### PR DESCRIPTION
**Description**:
An error with the leading zeroes was raised by our community. Solved it by fixing `ECDSAPrivateKey.toBytesRaw` function. It was appending the zeroes instead of prepending them when the key was too short.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
