### PR TITLE
feat: manual update client address book

### DIFF
--- a/examples/schedule-network-update.js
+++ b/examples/schedule-network-update.js
@@ -1,0 +1,74 @@
+import { AccountId, Client, PrivateKey } from "@hashgraph/sdk";
+
+import dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+    if (
+        process.env.OPERATOR_ID == null ||
+        process.env.OPERATOR_KEY == null ||
+        process.env.HEDERA_NETWORK == null
+    ) {
+        throw new Error(
+            "Environment variables OPERATOR_ID, HEDERA_NETWORK, and OPERATOR_KEY are required.",
+        );
+    }
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    const operatorKey = PrivateKey.fromStringECDSA(process.env.OPERATOR_KEY);
+
+    // Step 1: Initialize the client
+    const client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+        operatorId,
+        operatorKey,
+    );
+
+    console.log(
+        `Client initialized for network: ${client.ledgerId.toString()}`,
+    );
+
+    // Step 2: Examine the default network update period
+
+    let networkUpdateInMinutes = client.networkUpdatePeriod / (1000 * 60);
+
+    let networkUpdateInHours = client.networkUpdatePeriod / (1000 * 60 * 60);
+
+    console.log(
+        `The current default network update period is: ${networkUpdateInMinutes} minutes or ${networkUpdateInHours.toFixed(2)} hours.`,
+    );
+
+    /*
+     * Step 3: Update the address book of the client
+     * Note: This is optional, but it is recommended to keep the client with updated address book.
+     * This works only in node.js environment. For the browser client, the address book is handled by GRPC Web proxies.
+     */
+
+    console.log("Updating the address book of the client...");
+
+    await client.updateNetwork();
+
+    console.log("Address book updated successfully.");
+
+    /*
+     * Step 3: Change network update period to 1 hour
+     */
+
+    console.log("Changing network update period to 1 hour...");
+    const oneHourInMs = 1 * 60 * 60 * 1000;
+
+    client.setNetworkUpdatePeriod(oneHourInMs);
+
+    // Step 4: Examine the new network update period
+
+    networkUpdateInMinutes = client.networkUpdatePeriod / (1000 * 60);
+
+    networkUpdateInHours = client.networkUpdatePeriod / (1000 * 60 * 60);
+
+    console.log(
+        `The current network update period is: ${networkUpdateInMinutes} minutes or ${networkUpdateInHours.toFixed(2)} hours.`,
+    );
+
+    client.close();
+}
+
+void main();

--- a/examples/schedule-network-update.js
+++ b/examples/schedule-network-update.js
@@ -17,7 +17,12 @@ async function main() {
     const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
     const operatorKey = PrivateKey.fromStringECDSA(process.env.OPERATOR_KEY);
 
-    // Step 1: Initialize the client
+    /*
+     * Step 1: Initialize the client.
+     * Note: By default, the first network address book update will be triggered after 24 hours,
+     * and subsequent updates will occur every 24 hours.
+     * This is controlled by `networkUpdatePeriod`, which defaults to 86400000 milliseconds or 24 hours.
+     */
     const client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
         operatorId,
         operatorKey,

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -697,6 +697,17 @@ export default class Client {
     }
 
     /**
+     * Update the network address book.
+     * @returns {Promise<void>}
+     */
+    async updateNetwork() {
+        const addressBook = await CACHE.addressBookQueryConstructor()
+            .setFileId(FileId.ADDRESS_BOOK)
+            .execute(this);
+        this.setNetworkFromAddressBook(addressBook);
+    }
+
+    /**
      * @returns {void}
      */
     close() {
@@ -730,10 +741,7 @@ export default class Client {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises,@typescript-eslint/no-misused-promises
         this._timer = setTimeout(async () => {
             try {
-                const addressBook = await CACHE.addressBookQueryConstructor()
-                    .setFileId(FileId.ADDRESS_BOOK)
-                    .execute(this);
-                this.setNetworkFromAddressBook(addressBook);
+                await this.updateNetwork();
 
                 if (!this._isShutdown) {
                     // Recall this method to continuously update the network

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -127,6 +127,12 @@ export default class Client {
         /** @private */
         this._requestTimeout = null;
 
+        /**
+         * @private
+         * @type {boolean}
+         */
+        this._isUpdatingNetwork = false;
+
         /** @private */
         this._networkUpdatePeriod = 24 * 60 * 60 * 1000;
 
@@ -701,10 +707,28 @@ export default class Client {
      * @returns {Promise<void>}
      */
     async updateNetwork() {
-        const addressBook = await CACHE.addressBookQueryConstructor()
-            .setFileId(FileId.ADDRESS_BOOK)
-            .execute(this);
-        this.setNetworkFromAddressBook(addressBook);
+        if (this._isUpdatingNetwork) {
+            return;
+        }
+
+        this._isUpdatingNetwork = true;
+
+        try {
+            const addressBook = await CACHE.addressBookQueryConstructor()
+                .setFileId(FileId.ADDRESS_BOOK)
+                .execute(this);
+            this.setNetworkFromAddressBook(addressBook);
+        } catch (error) {
+            if (this._logger) {
+                this._logger.trace(
+                    `failed to update client address book: ${
+                        /** @type {Error} */ (error).toString()
+                    }`,
+                );
+            }
+        } finally {
+            this._isUpdatingNetwork = false;
+        }
     }
 
     /**
@@ -740,22 +764,12 @@ export default class Client {
         // This is the automatic network update promise that _eventually_ completes
         // eslint-disable-next-line @typescript-eslint/no-floating-promises,@typescript-eslint/no-misused-promises
         this._timer = setTimeout(async () => {
-            try {
-                await this.updateNetwork();
+            await this.updateNetwork();
 
-                if (!this._isShutdown) {
-                    // Recall this method to continuously update the network
-                    // every `networkUpdatePeriod` amount of itme
-                    this._scheduleNetworkUpdate();
-                }
-            } catch (error) {
-                if (this._logger) {
-                    this._logger.trace(
-                        `failed to update client address book: ${
-                            /** @type {Error} */ (error).toString()
-                        }`,
-                    );
-                }
+            if (!this._isShutdown) {
+                // Recall this method to continuously update the network
+                // every `networkUpdatePeriod` amount of itme
+                this._scheduleNetworkUpdate();
             }
         }, this._networkUpdatePeriod);
     }

--- a/src/client/WebClient.js
+++ b/src/client/WebClient.js
@@ -213,4 +213,14 @@ export default class WebClient extends Client {
             throw new Error("mirror support is not supported in browsers");
         };
     }
+
+    /**
+     * @override
+     * @returns {Promise<void>}
+     */
+    updateNetwork() {
+        return Promise.reject(
+            new Error("Update network is not supported in browsers"),
+        );
+    }
 }


### PR DESCRIPTION
### Description:
This gives the possibility of the sdk client to update the address book manually and adds an example of usage.

### **Note:**
Current flow of the client network update:
**Client initialization ->>> (Optional) Manual network update → Wait → Scheduled network update → Wait → Repeat...**

We chose this approach to allow users to update the network manually, because initiating the address book update during client initialization would introduce a breaking change to users. Since the update process is asynchronous, it would require awaiting the operation.

### Checklist:
- [x] Implemented method for updating the network manually.
- [x] Added example for usage of this method and update network period.

Related issues:
https://github.com/hiero-ledger/hiero-sdk-js/issues/2918

