### PR TITLE
fix: Enabled gRPC retry mechanism

### DIFF
--- a/src/channel/NodeChannel.js
+++ b/src/channel/NodeChannel.js
@@ -107,7 +107,7 @@ export default class NodeChannel extends Channel {
             "grpc.keepalive_time_ms": 100000,
             "grpc.keepalive_timeout_ms": 10000,
             "grpc.keepalive_permit_without_calls": 1,
-            "grpc.enable_retries": 0,
+            "grpc.enable_retries": 1,
         };
 
         // If the port is 50212, use TLS


### PR DESCRIPTION
**Description**:
This PR modifies the `gRPC` library settings and activates the retry feature within the channel, allowing it to attempt reconnection in case of a failure.

**Related issue(s)**:
#2926 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
