### PR TITLE
chore: break down task into build:prep and build:actual

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,10 +67,18 @@ tasks:
 
     build:
         cmds:
+            - task: build:prep
+            - task: build:actual
+
+    "build:prep":
+        cmds:
             - task: install
             - task: update:addressbooks
             - task: format
             - task: lint
+
+    "build:actual":
+        cmds:
             - npx babel src -d lib --out-file-extension .cjs > /dev/null
             - npx rollup -c > /dev/null
             - npx yalc publish > /dev/null


### PR DESCRIPTION
**Description**:
Reopenned https://github.com/hiero-ledger/hiero-sdk-js/pull/2388 because of some conflict in the old PR where the old nodes refused to rerun.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
