### PR TITLE
docs: add note in documentation when running examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ See [examples](./examples).
 Every example can be executed using the following command from the root directory: `node examples/[name-of-example].js`.
 
 **Note:** Before running any examples, ensure you have:
-1. Installed dependencies by running `pnpm install` in the `examples` directory
-2. Built the SDK by running `task build` in the root directory.
+
+1. Built the SDK by running `task build` in the root directory.
+2. Installed dependencies by running `pnpm install` in the `examples` directory
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ The Hiero JavaScript SDK does not currently support the following:
 
 See [examples](./examples).
 
-Every example can be executed using the following command from the root directory: `node examples/[name-of-example].js`
+Every example can be executed using the following command from the root directory: `node examples/[name-of-example].js`.
+
+**Note:** Before running any examples, ensure you have:
+1. Installed dependencies by running `pnpm install` in the `examples` directory
+2. Built the SDK by running `task build` in the root directory.
 
 ## Configuration
 


### PR DESCRIPTION
**Description**:
Users weren't aware they need to build the project and then install the dependencies before running the example.

Fixes #
https://github.com/hiero-ledger/hiero-sdk-js/issues/2535

**Checklist**

- [x] Documented (Code comments, README, etc.)
