### PR TITLE
chore(release): v2.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.61.0
+
+-   fix: disable auto renew assignment on topic and token create by @SimiHunjan in @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2945
+-   feat: manual update client address book by @venilinvasilev in https://github.com/hiero-ledger/hiero-sdk-js/pull/2928
+-   docs: add some comments about the toSolidityAddress function by @Neurone in https://github.com/hiero-ledger/hiero-sdk-js/pull/2220
+-   docs: add note in documentation when running examples by @ivaylonikolov7 in https://github.com/hiero-ledger/hiero-sdk-js/pull/2962
+-   chore(deps): bump @babel/runtime in /examples/react-native-example by @dependabot in 
+https://github.com/hiero-ledger/hiero-sdk-js/pull/2947
+-   chore(deps): bump @babel/helpers in /examples/react-native-example by @dependabot in 
+https://github.com/hiero-ledger/hiero-sdk-js/pull/2949
+-   chore(deps): bump @babel/helpers from 7.26.0 to 7.26.10 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2948
+-   chore(deps): bump axios from 1.7.9 to 1.8.2 in /examples by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2942
+-   chore(deps): bump @babel/helpers by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2951
+-   chore(deps): bump @babel/runtime from 7.26.0 to 7.26.10 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2950
+-   chore(deps): bump actions/setup-node from 4.2.0 to 4.3.0 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2958
+-   chore(deps): bump renovatebot/github-action from 41.0.14 to 41.0.15 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2957
+
 ## v2.61.0-beta.2
 
 -   feat: Verify the SDK can use .setMirrorNetwork() with Solo by @ivaylogarnev-limechain in https://github.com/hiero-ledger/hiero-sdk-js/pull/2933

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.61.0-beta.2",
+    "version": "2.61.0",
     "description": "Hiero SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",


### PR DESCRIPTION
Stable release v2.61.0

## v2.61.0

-   fix: disable auto renew assignment on topic and token create by @SimiHunjan in @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2945
-   feat: manual update client address book by @venilinvasilev in https://github.com/hiero-ledger/hiero-sdk-js/pull/2928
-   docs: add some comments about the toSolidityAddress function by @Neurone in https://github.com/hiero-ledger/hiero-sdk-js/pull/2220
-   docs: add note in documentation when running examples by @ivaylonikolov7 in https://github.com/hiero-ledger/hiero-sdk-js/pull/2962
-   chore(deps): bump @babel/runtime in /examples/react-native-example by @dependabot in 
https://github.com/hiero-ledger/hiero-sdk-js/pull/2947
-   chore(deps): bump @babel/helpers in /examples/react-native-example by @dependabot in 
https://github.com/hiero-ledger/hiero-sdk-js/pull/2949
-   chore(deps): bump @babel/helpers from 7.26.0 to 7.26.10 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2948
-   chore(deps): bump axios from 1.7.9 to 1.8.2 in /examples by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2942
-   chore(deps): bump @babel/helpers by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2951
-   chore(deps): bump @babel/runtime from 7.26.0 to 7.26.10 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2950
-   chore(deps): bump actions/setup-node from 4.2.0 to 4.3.0 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2958
-   chore(deps): bump renovatebot/github-action from 41.0.14 to 41.0.15 by @dependabot in https://github.com/hiero-ledger/hiero-sdk-js/pull/2957