### PR TITLE
refactor: remove account creation in integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
       - name: "Create env file"
         run: |
           touch .env
-          echo OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo OPERATOR_ID="0.0.2" >> .env
+          echo OPERATOR_KEY="0xa608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+          echo OPERATOR_ID="0.0.1022" >> .env
           echo HEDERA_NETWORK="local-node" >> .env
           cat .env
 

--- a/src/token/TokenCreateTransaction.js
+++ b/src/token/TokenCreateTransaction.js
@@ -571,7 +571,7 @@ export default class TokenCreateTransaction extends Transaction {
         }
         return super.freezeWith(client);
     }
-    
+
     /**
      * @param {Key} key
      * @returns {this}

--- a/test/integration/ContractFunctionParametersIntegrationTest.js
+++ b/test/integration/ContractFunctionParametersIntegrationTest.js
@@ -123,7 +123,7 @@ describe("ContractFunctionParameters", function () {
     let newContractId;
 
     before(async function () {
-        env = await IntegrationTestEnv.new({ balance: 100000 });
+        env = await IntegrationTestEnv.new();
         // Create a file on Hedera and store the bytecode
         const fileCreateTx = new FileCreateTransaction()
             .setKeys([env.operatorKey])

--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -22,7 +22,7 @@ describe("TokenAssociate", function () {
     let env;
 
     before(async function () {
-        env = await IntegrationTestEnv.new({ balance: 1000 });
+        env = await IntegrationTestEnv.new();
     });
 
     it("should be executable", async function () {

--- a/test/integration/TokenUpdateIntegrationTest.js
+++ b/test/integration/TokenUpdateIntegrationTest.js
@@ -21,7 +21,7 @@ describe("TokenUpdate", function () {
     let env;
 
     before(async function () {
-        env = await IntegrationTestEnv.new({ balance: 1000 });
+        env = await IntegrationTestEnv.new();
     });
 
     it("should be executable", async function () {


### PR DESCRIPTION
**Description**:
This update resolves an issue in the integration tests where the dedicated test account could run out of Hbar, leading to INSUFFICIENT_PAYER_BALANCE errors when running large test suites. Going forward, the tests will use one of the auto-generated accounts provided by the local node, ensuring sufficient balance and more stable test execution across all suites.

**Related issue(s)**:
https://github.com/hiero-ledger/hiero-sdk-js/issues/2964

Fixes #
https://github.com/hiero-ledger/hiero-sdk-js/issues/2964
