### PR TITLE
build: disable treeshaking for queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
         "transactions"
     ],
     "sideEffects": [
-        "./src/query/Query.js",
-        "./src/query/CostQuery.js",
-        "**/*Query.js"
+        "**/*Query.js",
+        "**/browser.js"
     ],
     "files": [
         "lib/",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
         "sdk",
         "transactions"
     ],
-    "sideEffects": false,
+    "sideEffects": [
+        "./src/query/Query.js",
+        "./src/query/CostQuery.js",
+        "**/*Query.js"
+    ],
     "files": [
         "lib/",
         "src/"


### PR DESCRIPTION
**Description**:

Disable treeshaking for queries. Queries are treeshaken on webpack build which breaks the CostQuery. 

**Checklist**

- [x] Tested (unit, integration, etc.)
