### PR TITLE
fix: remove circular dependancy in dependencies

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -210,5 +210,3 @@ export const NetworkName = {
     Testnet: "testnet",
     Previewnet: "previewnet",
 };
-
-import "./query/CostQuery.js";

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -4,8 +4,8 @@ import TransactionId from "../transaction/TransactionId.js";
 import Hbar from "../Hbar.js";
 import Executable from "../Executable.js";
 import AccountId from "../account/AccountId.js";
-import { _makePaymentTransaction, COST_QUERY } from "./Query.js";
 import * as HieroProto from "@hashgraph/proto";
+import Long from "long";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
@@ -187,4 +187,89 @@ export default class CostQuery extends Executable {
     }
 }
 
-COST_QUERY.push((query) => new CostQuery(query));
+/**
+ * Generate a payment transaction given, aka. `TransferTransaction`
+ *
+ * @param {TransactionId} paymentTransactionId
+ * @param {AccountId} nodeId
+ * @param {?import("../Executable.js").ClientOperator} operator
+ * @param {Hbar} paymentAmount
+ * @returns {Promise<HieroProto.proto.ITransaction>}
+ */
+export async function _makePaymentTransaction(
+    paymentTransactionId,
+    nodeId,
+    operator,
+    paymentAmount,
+) {
+    const accountAmounts = [];
+
+    // If an operator is provided then we should make sure we transfer
+    // from the operator to the node.
+    // If an operator is not provided we simply create an effectively
+    // empty account amounts
+    if (operator != null) {
+        accountAmounts.push({
+            accountID: operator.accountId._toProtobuf(),
+            amount: paymentAmount.negated().toTinybars(),
+        });
+        accountAmounts.push({
+            accountID: nodeId._toProtobuf(),
+            amount: paymentAmount.toTinybars(),
+        });
+    } else {
+        accountAmounts.push({
+            accountID: new AccountId(0)._toProtobuf(),
+            // If the account ID is 0, shouldn't we just hard
+            // code this value to 0? Same for the latter.
+            amount: paymentAmount.negated().toTinybars(),
+        });
+        accountAmounts.push({
+            accountID: nodeId._toProtobuf(),
+            amount: paymentAmount.toTinybars(),
+        });
+    }
+    /**
+     * @type {HieroProto.proto.ITransactionBody}
+     */
+    const body = {
+        transactionID: paymentTransactionId._toProtobuf(),
+        nodeAccountID: nodeId._toProtobuf(),
+        transactionFee: new Hbar(1).toTinybars(),
+        transactionValidDuration: {
+            seconds: Long.fromNumber(120),
+        },
+        cryptoTransfer: {
+            transfers: {
+                accountAmounts,
+            },
+        },
+    };
+
+    /** @type {HieroProto.proto.ISignedTransaction} */
+    const signedTransaction = {
+        bodyBytes: HieroProto.proto.TransactionBody.encode(body).finish(),
+    };
+
+    // Sign the transaction if an operator is provided
+    //
+    // We have _several_ places where we build the transactions, maybe this is
+    // something we can deduplicate?
+    if (operator != null) {
+        const signature = await operator.transactionSigner(
+            /** @type {Uint8Array} */ (signedTransaction.bodyBytes),
+        );
+
+        signedTransaction.sigMap = {
+            sigPair: [operator.publicKey._toProtobufSignature(signature)],
+        };
+    }
+
+    // Create and return a `proto.Transaction`
+    return {
+        signedTransactionBytes:
+            HieroProto.proto.SignedTransaction.encode(
+                signedTransaction,
+            ).finish(),
+    };
+}

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -8,6 +8,7 @@ import TransactionId from "../transaction/TransactionId.js";
 import * as HieroProto from "@hashgraph/proto";
 import PrecheckStatusError from "../PrecheckStatusError.js";
 import MaxQueryPaymentExceeded from "../MaxQueryPaymentExceeded.js";
+import CostQuery from "./CostQuery.js";
 import Long from "long";
 
 /**
@@ -161,13 +162,9 @@ export default class Query extends Executable {
             );
         }
 
-        if (COST_QUERY.length != 1) {
-            throw new Error("CostQuery has not been loaded yet");
-        }
-
         // Change the timestamp. Should we be doing this?
         this._timestamp = Date.now();
-        const cost = await COST_QUERY[0](this).execute(client);
+        const cost = await new CostQuery(this).execute(client);
         return Hbar.fromTinybars(
             cost._valueInTinybar.multipliedBy(1.1).toFixed(0),
         );
@@ -615,10 +612,3 @@ export async function _makePaymentTransaction(
             ).finish(),
     };
 }
-
-/**
- * Cache for the cost query constructor. This prevents cyclic dependencies.
- *
- * @type {((query: Query<*>) => import("./CostQuery.js").default<*>)[]}
- */
-export const COST_QUERY = [];


### PR DESCRIPTION
**Description**:

Circular dependency workaround was breaking our webpack build and treeshaking code that was actually necessary. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
