### PR TITLE
chore: remove github-committers team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,23 +8,23 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hiero-ledger/github-committers @hiero-ledger/github-maintainers
-/.github/workflows/                             @hiero-ledger/github-committers @hiero-ledger/github-maintainers
+/.github/                                       @hiero-ledger/github-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers
 
 # Codacy Tool Configurations
-/config/                                        @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-committers @hiero-ledger/github-maintainers
-.remarkrc                                       @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-committers @hiero-ledger/github-maintainers
+/config/                                        @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-maintainers
+.remarkrc                                       @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/hiero-sdk-js-committers @hiero-ledger/tsc
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/hiero-sdk-js-committers @hiero-ledger/tsc
 **/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
 
 # CodeCov configuration
-**/codecov.yml                                  @hiero-ledger/github-committers @hiero-ledger/github-maintainers
+**/codecov.yml                                  @hiero-ledger/github-maintainers
 
 # Git Ignore definitions
-**/.gitignore                                   @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
-**/.gitignore.*                                 @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
+**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
+**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc


### PR DESCRIPTION
**Description**:

Remove `github-committers` team from codeowners file

**Related Issue(s)**:

Fixes #2990
