### PR TITLE
fix: accountId instantiated from EVM address incorrectly sets evmAddress

### DIFF
--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -320,12 +320,35 @@ export default class AccountId {
             evmAddress = this.evmAddress._bytes;
         } */
 
+        const isHollowAccount = this.num.eq(Long.fromBigInt(0n)) && alias;
+
+        if (isHollowAccount) {
+            return {
+                alias,
+                accountNum: null,
+                shardNum: this.shard,
+                realmNum: this.realm,
+            };
+        } else if (this.num && alias) {
+            return {
+                alias: null,
+                accountNum: this.num,
+                shardNum: this.shard,
+                realmNum: this.realm,
+            };
+        } else if (alias) {
+            return {
+                alias,
+                accountNum: null,
+                shardNum: this.shard,
+                realmNum: this.realm,
+            };
+        }
         return {
-            alias,
-            accountNum: this.aliasKey != null ? null : this.num,
+            alias: null,
+            accountNum: this.num,
             shardNum: this.shard,
             realmNum: this.realm,
-            //evmAddress,
         };
     }
 

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -323,6 +323,7 @@ export default class AccountId {
         const isHollowAccount = this.num.eq(Long.fromBigInt(0n)) && alias;
 
         if (isHollowAccount) {
+            // if is hollow accont pass accountNum null
             return {
                 alias,
                 accountNum: null,
@@ -330,6 +331,7 @@ export default class AccountId {
                 realmNum: this.realm,
             };
         } else if (this.num && alias) {
+            // if both num and alias are set ignore the alias
             return {
                 alias: null,
                 accountNum: this.num,
@@ -337,6 +339,7 @@ export default class AccountId {
                 realmNum: this.realm,
             };
         } else if (alias) {
+            // then if alias is set ignore the account num
             return {
                 alias,
                 accountNum: null,
@@ -344,6 +347,7 @@ export default class AccountId {
                 realmNum: this.realm,
             };
         }
+        // all other cases ignore the alias
         return {
             alias: null,
             accountNum: this.num,

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -322,32 +322,14 @@ export default class AccountId {
 
         const isHollowAccount = this.num.eq(Long.fromBigInt(0n)) && alias;
 
-        if (isHollowAccount) {
-            // if is hollow accont pass accountNum null
+        if (alias) {
             return {
-                alias,
-                accountNum: null,
-                shardNum: this.shard,
-                realmNum: this.realm,
-            };
-        } else if (this.num && alias) {
-            // if both num and alias are set ignore the alias
-            return {
-                alias: null,
-                accountNum: this.num,
-                shardNum: this.shard,
-                realmNum: this.realm,
-            };
-        } else if (alias) {
-            // then if alias is set ignore the account num
-            return {
-                alias,
-                accountNum: null,
+                alias: isHollowAccount ? alias : null,
+                accountNum: isHollowAccount ? null : this.num,
                 shardNum: this.shard,
                 realmNum: this.realm,
             };
         }
-        // all other cases ignore the alias
         return {
             alias: null,
             accountNum: this.num,


### PR DESCRIPTION
**Description**:
This PR improves the handling of account aliases and hollow accounts in the AccountId class by making the protobuf conversion more explicit and adding comprehensive test coverage.

- Add support for hollow account detection (num=0 with alias)
- More explicing protobuff conversion when:
   1.  both `AccountId` `num` and `alias` are set
   2. only `alias` is set
   3. only `AccountId` `num` is set


Fixes #2982

**Notes for reviewer**: I am aware that there is some shorter syntax with the tenary operator but I don't think it's worth to safe a bunch of bytes at the cost of readability of the code. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
