### PR TITLE
feat: update module resolution to node16

### DIFF
--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -3,7 +3,6 @@
     "version": "1.6.0-beta.1",
     "description": "Cryptographic utilities and primitives for the Hiero SDK",
     "main": "./lib/index.cjs",
-    "types": "./lib/index.d.ts",
     "module": "./src/index.js",
     "react-native": {
         "./lib/index.cjs": "./src/index.native.js",
@@ -29,7 +28,8 @@
         "./package.json": "./package.json",
         ".": {
             "import": "./src/index.js",
-            "require": "./lib/index.cjs"
+            "require": "./lib/index.cjs",
+            "types": "./lib/index.d.ts"
         }
     },
     "license": "Apache-2.0",

--- a/packages/cryptography/src/BadKeyError.js
+++ b/packages/cryptography/src/BadKeyError.js
@@ -13,11 +13,11 @@ export default class BadKeyError extends Error {
         );
 
         this.name = "BadKeyError";
-
+        this.stack = "";
         if (messageOrCause instanceof Error) {
             /** @type {Error=} */
             this.cause = messageOrCause;
-            this.stack = messageOrCause.stack;
+            this.stack = messageOrCause.stack || this.stack || "";
         }
     }
 }

--- a/src/BadEntityIdError.js
+++ b/src/BadEntityIdError.js
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @typedef {import("long").default} Long
+ */
+
 export default class BadEntityIdError extends Error {
     /**
      * @param {Long} shard

--- a/src/EthereumFlow.js
+++ b/src/EthereumFlow.js
@@ -28,7 +28,7 @@ import * as hex from "./encoding/hex.js";
  * @typedef {import("./Timestamp.js").default} Timestamp
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
  * @typedef {import("./transaction/TransactionResponse.js").default} TransactionResponse
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/EthereumTransaction.js
+++ b/src/EthereumTransaction.js
@@ -24,7 +24,7 @@ import Transaction, {
  * @typedef {import("./client/Client.js").default<*, *>} Client
  * @typedef {import("./Timestamp.js").default} Timestamp
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/Hbar.js
+++ b/src/Hbar.js
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import { valueToLong } from "./long.js";
 import HbarUnit from "./HbarUnit.js";
 
 import Long from "long";
-
-/**
- * @typedef {import("./long.js").LongObject} LongObject
- */
 
 /**
  * Represents a quantity of hbar (ℏ), the native currency of the Hedera network.
@@ -16,7 +12,7 @@ import Long from "long";
  */
 export default class Hbar {
     /**
-     * @param {number | string | Long | LongObject | BigNumber} amount
+     * @param {number | string | Long | BigNumber} amount
      * @param {HbarUnit=} unit
      */
     constructor(amount, unit = HbarUnit.Hbar) {

--- a/src/HbarUnit.js
+++ b/src/HbarUnit.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 
 /**
  * Represents a unit of HBAR currency measurement in the Hedera network.

--- a/src/RecordStatusError.js
+++ b/src/RecordStatusError.js
@@ -5,7 +5,7 @@ import StatusError from "./StatusError.js";
 /**
  * @typedef {import("./Status.js").default} Status
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
- * @typedef {import("./transaction/TransactionRecord").default} TransactionRecord
+ * @typedef {import("./transaction/TransactionRecord.js").default} TransactionRecord
  */
 
 export default class RecordStatusError extends StatusError {

--- a/src/StakingInfo.js
+++ b/src/StakingInfo.js
@@ -6,7 +6,7 @@ import Timestamp from "./Timestamp.js";
 import * as HieroProto from "@hashgraph/proto";
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/Transfer.js
+++ b/src/Transfer.js
@@ -18,7 +18,7 @@ import Hbar from "./Hbar.js";
 
 /**
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/account/AccountAllowanceAdjustTransaction.js
+++ b/src/account/AccountAllowanceAdjustTransaction.js
@@ -28,7 +28,6 @@ import * as util from "../util.js";
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("../long.js").LongObject} LongObject
  */
 
 /**
@@ -77,7 +76,7 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
     /**
      * @deprecated
      * @param {AccountId | string} spenderAccountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @returns {AccountAllowanceAdjustTransaction}
      */
     addHbarAllowance(spenderAccountId, amount) {
@@ -131,7 +130,7 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
      * @deprecated
      * @param {AccountId | string} ownerAccountId
      * @param {AccountId | string} spenderAccountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @returns {AccountAllowanceAdjustTransaction}
      */
     grantHbarAllowance(ownerAccountId, spenderAccountId, amount) {
@@ -147,7 +146,7 @@ export default class AccountAllowanceAdjustTransaction extends Transaction {
      * @deprecated
      * @param {AccountId | string} ownerAccountId
      * @param {AccountId | string} spenderAccountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long  | BigNumber | Hbar} amount
      * @returns {AccountAllowanceAdjustTransaction}
      */
     revokeHbarAllowance(ownerAccountId, spenderAccountId, amount) {

--- a/src/account/AccountAllowanceApproveTransaction.js
+++ b/src/account/AccountAllowanceApproveTransaction.js
@@ -30,7 +30,6 @@ import TokenNftAllowance from "./TokenNftAllowance.js";
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("../long.js").LongObject} LongObject
  */
 
 /**
@@ -123,7 +122,7 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
     /**
      * @param {AccountId | string} ownerAccountId
      * @param {AccountId | ContractId | string} spenderAccountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @returns {AccountAllowanceApproveTransaction}
      */
     approveHbarAllowance(ownerAccountId, spenderAccountId, amount) {
@@ -161,7 +160,7 @@ export default class AccountAllowanceApproveTransaction extends Transaction {
     /**
      * @deprecated - Use `approveHbarAllowance()` instead
      * @param {AccountId | string} spenderAccountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @returns {AccountAllowanceApproveTransaction}
      */
     addHbarAllowance(spenderAccountId, amount) {

--- a/src/account/AccountAllowanceDeleteTransaction.js
+++ b/src/account/AccountAllowanceDeleteTransaction.js
@@ -25,7 +25,6 @@ import TokenNftAllowance from "./TokenNftAllowance.js";
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("../long.js").LongObject} LongObject
  */
 
 /**

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -19,7 +19,7 @@ import { isLongZeroAddress } from "../util.js";
  */
 export default class AccountId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      * @param {(PublicKey)=} aliasKey

--- a/src/account/HbarAllowance.js
+++ b/src/account/HbarAllowance.js
@@ -11,7 +11,7 @@ import Hbar from "../Hbar.js";
  */
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/account/HbarTransferMap.js
+++ b/src/account/HbarTransferMap.js
@@ -11,7 +11,6 @@ import ObjectMap from "../ObjectMap.js";
  */
 
 /**
- * @typedef {import("../long.js").LongObject} LongObject
  * @typedef {import("bignumber.js").default} BigNumber
  */
 

--- a/src/account/LiveHashAddTransaction.js
+++ b/src/account/LiveHashAddTransaction.js
@@ -23,6 +23,7 @@ import KeyList from "../KeyList.js";
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/account/TokenBalanceMap.js
+++ b/src/account/TokenBalanceMap.js
@@ -10,7 +10,7 @@ import ObjectMap from "../ObjectMap.js";
  */
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/account/TokenRelationshipMap.js
+++ b/src/account/TokenRelationshipMap.js
@@ -11,7 +11,7 @@ import ObjectMap from "../ObjectMap.js";
  */
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/account/TokenTransferAccountMap.js
+++ b/src/account/TokenTransferAccountMap.js
@@ -4,6 +4,10 @@ import AccountId from "../account/AccountId.js";
 import ObjectMap from "../ObjectMap.js";
 
 /**
+ * @typedef {import("long").default} Long
+ */
+
+/**
  * @augments {ObjectMap<AccountId, Long>}
  */
 export default class TokenTransferAccountMap extends ObjectMap {

--- a/src/account/TransferTransaction.js
+++ b/src/account/TransferTransaction.js
@@ -14,7 +14,6 @@ import NftId from "../token/NftId.js";
 import AbstractTokenTransferTransaction from "../token/AbstractTokenTransferTransaction.js";
 
 /**
- * @typedef {import("../long.js").LongObject} LongObject
  * @typedef {import("bignumber.js").default} BigNumber
  */
 
@@ -167,7 +166,7 @@ export default class TransferTransaction extends AbstractTokenTransferTransactio
     /**
      * @internal
      * @param {AccountId | string} accountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @param {boolean} isApproved
      * @returns {TransferTransaction}
      */
@@ -203,7 +202,7 @@ export default class TransferTransaction extends AbstractTokenTransferTransactio
     /**
      * @internal
      * @param {AccountId | string} accountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long  | BigNumber | Hbar} amount
      * @returns {TransferTransaction}
      */
     addHbarTransfer(accountId, amount) {
@@ -213,7 +212,7 @@ export default class TransferTransaction extends AbstractTokenTransferTransactio
     /**
      * @internal
      * @param {AccountId | string} accountId
-     * @param {number | string | Long | LongObject | BigNumber | Hbar} amount
+     * @param {number | string | Long | BigNumber | Hbar} amount
      * @returns {TransferTransaction}
      */
     addApprovedHbarTransfer(accountId, amount) {

--- a/src/address_book/NodeAddress.js
+++ b/src/address_book/NodeAddress.js
@@ -11,7 +11,7 @@ import * as utf8 from "../encoding/utf8.js";
 
 /**
  * @typedef {import("./Endpoint.js").EndPointJson} EndpointJson
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/contract/ContractCreateFlow.js
+++ b/src/contract/ContractCreateFlow.js
@@ -28,7 +28,7 @@ import PublicKey from "../PublicKey.js";
 
 /**
  * @typedef {import("bignumber.js").BigNumber} BigNumber
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/contract/ContractFunctionParameters.js
+++ b/src/contract/ContractFunctionParameters.js
@@ -7,7 +7,7 @@ import ContractFunctionSelector, {
 import * as utf8 from "../encoding/utf8.js";
 import * as hex from "../encoding/hex.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import * as util from "../util.js";
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { arrayify } from "@ethersproject/bytes";

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -3,7 +3,7 @@
 import ContractLogInfo from "./ContractLogInfo.js";
 import ContractId from "./ContractId.js";
 import AccountId from "../account/AccountId.js";
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import * as hex from "../encoding/hex.js";
 import * as utf8 from "../encoding/utf8.js";
 import * as util from "../util.js";

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -18,7 +18,7 @@ import { isLongZeroAddress } from "../util.js";
  */
 export default class ContractId extends Key {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      * @param {Uint8Array=} evmAddress

--- a/src/contract/DelegateContractId.js
+++ b/src/contract/DelegateContractId.js
@@ -11,7 +11,7 @@ import * as hex from "../encoding/hex.js";
  */
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  * @typedef {import("../client/Client.js").default<*, *>} Client
  */
 
@@ -21,7 +21,7 @@ import * as hex from "../encoding/hex.js";
  */
 export default class DelegateContractId extends ContractId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      * @param {Uint8Array=} evmAddress

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -13,7 +13,7 @@ import Long from "long";
  */
 export default class FileId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      */

--- a/src/logger/Logger.js
+++ b/src/logger/Logger.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import pino from "pino";
+import { pino } from "pino";
 import LogLevel from "./LogLevel.js";
 
 /**

--- a/src/long.js
+++ b/src/long.js
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 
 /**
- * @typedef {{low: number, high: number, unsigned: boolean}} LongObject
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  */
 
 /**
- * @param {Long | number | string | LongObject | BigNumber} value
+ * @param {Long | number | string | BigNumber} value
  * @returns {BigNumber}
  */
 export function valueToLong(value) {

--- a/src/node/NodeDeleteTransaction.js
+++ b/src/node/NodeDeleteTransaction.js
@@ -23,6 +23,7 @@ import Transaction, {
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/node/NodeUpdateTransaction.js
+++ b/src/node/NodeUpdateTransaction.js
@@ -29,6 +29,7 @@ const SERVICE_ENDPOINTS_MAX_LENGTH = 8;
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/query/MirrorNodeContractQuery.js
+++ b/src/query/MirrorNodeContractQuery.js
@@ -1,10 +1,10 @@
 import ContractFunctionParameters from "../contract/ContractFunctionParameters.js";
 
 /**
- * @typedef {import("../contract/ContractId").default} ContractId
- * @typedef {import("../account/AccountId").default} AccountId
+ * @typedef {import("../contract/ContractId.js").default} ContractId
+ * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../client/Client.js").default<*, *>} Client
- *
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/schedule/ScheduleId.js
+++ b/src/schedule/ScheduleId.js
@@ -4,7 +4,7 @@ import * as entity_id from "../EntityIdHelper.js";
 import * as HieroProto from "@hashgraph/proto";
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  * @typedef {import("../client/Client.js").default<*, *>} Client
  */
 
@@ -20,7 +20,7 @@ import * as HieroProto from "@hashgraph/proto";
 
 export default class ScheduleId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      */

--- a/src/token/TokenId.js
+++ b/src/token/TokenId.js
@@ -4,7 +4,7 @@ import * as entity_id from "../EntityIdHelper.js";
 import * as HieroProto from "@hashgraph/proto";
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  * @typedef {import("../client/Client.js").default<*, *>} Client
  */
 
@@ -13,7 +13,7 @@ import * as HieroProto from "@hashgraph/proto";
  */
 export default class TokenId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      */

--- a/src/token/TokenNftsUpdateTransaction.js
+++ b/src/token/TokenNftsUpdateTransaction.js
@@ -21,6 +21,7 @@ import Transaction, {
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/token/TokenUpdateNftsTransaction.js
+++ b/src/token/TokenUpdateNftsTransaction.js
@@ -21,6 +21,7 @@ import Transaction, {
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -26,6 +26,7 @@ import TokenKeyValidation from "./TokenKeyValidation.js";
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/topic/TopicCreateTransaction.js
+++ b/src/topic/TopicCreateTransaction.js
@@ -24,6 +24,7 @@ import Hbar from "../Hbar.js";
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -4,7 +4,7 @@ import * as entity_id from "../EntityIdHelper.js";
 import * as HieroProto from "@hashgraph/proto";
 
 /**
- * @typedef {import("long")} Long
+ * @typedef {import("long").default} Long
  * @typedef {import("../client/Client.js").default<*, *>} Client
  */
 
@@ -13,7 +13,7 @@ import * as HieroProto from "@hashgraph/proto";
  */
 export default class TopicId {
     /**
-     * @param {number | Long | import("../EntityIdHelper").IEntityId} props
+     * @param {number | Long | import("../EntityIdHelper.js").IEntityId} props
      * @param {(number | Long)=} realm
      * @param {(number | Long)=} num
      */

--- a/src/topic/TopicMessage.js
+++ b/src/topic/TopicMessage.js
@@ -62,9 +62,7 @@ export default class TopicMessage {
                     : new Uint8Array(),
             sequenceNumber:
                 response.sequenceNumber != null
-                    ? response.sequenceNumber instanceof Long
-                        ? response.sequenceNumber
-                        : Long.fromNumber(response.sequenceNumber)
+                    ? response.sequenceNumber
                     : Long.ZERO,
             initialTransactionId:
                 response.chunkInfo != null &&

--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -24,6 +24,7 @@ import CustomFixedFee from "../token/CustomFixedFee.js";
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
+ * @typedef {import("long").default} Long
  */
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import Long from "long";
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "esnext",
-        "module": "esnext",
+        "module": "Node16",
         "lib": ["ESNext", "DOM"],
         "allowJs": true,
         "checkJs": true,
@@ -16,7 +16,7 @@
         "downlevelIteration": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
-        "moduleResolution": "node",
+        "moduleResolution": "Node16",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
**Description**:
- Modernize module resolution for Node16 compatibility
- Update tsconfig.json to use Node16 module and moduleResolution
- Update cryptography package to support new types
- Fix import statements across multiple files for Node16 module resolution compatibility

**Related issue(s)**: #2722

Issue #2722 is now addressed by #4313, which resolves it without the major-version tsconfig migration; this PR remains open for the broader modernization only.

**Notes for reviewer**:
This could be potentially a **BREAKING CHANGE** but the current tsconfig settings in our SDK are already deprecated by Typescript.

This is the setting in `tsconfig.json` that is deprecated by Typescript: 

`"moduleResolution": "node",`

This setting says `node: Deprecated, use "node10" in TypeScript 5.0+ instead` but the recommended ones are `node16` and `nodenext`. 

We could keep this for our incoming major version bump and keep this openned until the incoming major version change. 

