### PR TITLE
fix(hip-991): null fees handling

### DIFF
--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -104,9 +104,9 @@ export default class TopicUpdateTransaction extends Transaction {
 
         /**
          * @private
-         * @type {Key[]}
+         * @type {?Key[]}
          */
-        this._feeExemptKeys = [];
+        this._feeExemptKeys = null;
 
         if (props.feeExemptKeys != null) {
             this.setFeeExemptKeys(props.feeExemptKeys);
@@ -134,9 +134,9 @@ export default class TopicUpdateTransaction extends Transaction {
 
         /**
          * @private
-         * @type {CustomFixedFee[]}
+         * @type {?CustomFixedFee[]}
          */
-        this._customFees = [];
+        this._customFees = null;
 
         if (props.customFees != null) {
             this.setCustomFees(props.customFees);
@@ -404,7 +404,7 @@ export default class TopicUpdateTransaction extends Transaction {
 
     /**
      * Returns the keys that will be exempt from paying fees.
-     * @returns {Key[]}
+     * @returns {?Key[]}
      */
     getFeeExemptKeys() {
         return this._feeExemptKeys;
@@ -429,6 +429,10 @@ export default class TopicUpdateTransaction extends Transaction {
      */
     addFeeExemptKey(key) {
         this._requireNotFrozen();
+        if (this._feeExemptKeys == null) {
+            this._feeExemptKeys = [];
+        }
+
         this._feeExemptKeys.push(key);
 
         return this;
@@ -440,7 +444,7 @@ export default class TopicUpdateTransaction extends Transaction {
      */
     clearFeeExemptKeys() {
         this._requireNotFrozen();
-        this._feeExemptKeys = [];
+        this._feeExemptKeys = null;
 
         return this;
     }
@@ -501,7 +505,7 @@ export default class TopicUpdateTransaction extends Transaction {
 
     /**
      * Returns the fixed fees to assess when a message is submitted to the new topic.
-     * @returns {CustomFixedFee[]}
+     * @returns {?CustomFixedFee[]}
      */
     getCustomFees() {
         return this._customFees;
@@ -528,6 +532,10 @@ export default class TopicUpdateTransaction extends Transaction {
      */
     addCustomFee(customFee) {
         this._requireNotFrozen();
+        if (this._customFees == null) {
+            this._customFees = [];
+        }
+
         this._customFees.push(customFee);
 
         return this;
@@ -540,7 +548,7 @@ export default class TopicUpdateTransaction extends Transaction {
      */
     clearCustomFees() {
         this._requireNotFrozen();
-        this._customFees = [];
+        this._customFees = null;
 
         return this;
     }
@@ -596,9 +604,14 @@ export default class TopicUpdateTransaction extends Transaction {
                 this._feeScheduleKey != null
                     ? this._feeScheduleKey._toProtobufKey()
                     : null,
-            feeExemptKeyList: {
-                keys: this._feeExemptKeys.map((key) => key._toProtobufKey()),
-            },
+            feeExemptKeyList:
+                this._feeExemptKeys != null
+                    ? {
+                          keys: this._feeExemptKeys.map((key) =>
+                              key._toProtobufKey(),
+                          ),
+                      }
+                    : null,
             memo:
                 this._topicMemo != null
                     ? {
@@ -613,11 +626,14 @@ export default class TopicUpdateTransaction extends Transaction {
                 this._autoRenewPeriod != null
                     ? this._autoRenewPeriod._toProtobuf()
                     : null,
-            customFees: {
-                fees: this._customFees.map((customFee) =>
-                    customFee._toTopicFeeProtobuf(),
-                ),
-            },
+            customFees:
+                this._customFees != null
+                    ? {
+                          fees: this._customFees.map((customFee) =>
+                              customFee._toTopicFeeProtobuf(),
+                          ),
+                      }
+                    : null,
             expirationTime:
                 this._expirationTime != null
                     ? this._expirationTime._toProtobuf()

--- a/test/integration/TopicUpdateIntegrationTest.js
+++ b/test/integration/TopicUpdateIntegrationTest.js
@@ -1,0 +1,157 @@
+import {
+    CustomFixedFee,
+    PrivateKey,
+    TopicCreateTransaction,
+    TopicInfoQuery,
+    TopicUpdateTransaction,
+} from "../../src/exports.js";
+import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+import { createFungibleToken } from "./utils/Fixtures.js";
+
+/**
+ * @typedef {import("./client/BaseIntegrationTestEnv.js").default} BaseIntegrationTestEnv
+ */
+
+describe("TopicUpdate", function () {
+    /**
+     * @type {BaseIntegrationTestEnv}
+     */
+    let env;
+
+    beforeEach(async function () {
+        env = await IntegrationTestEnv.new();
+    });
+
+    describe("HIP-991: Permissionless revenue generating topics", function () {
+        it("should maintain empty list state for feeExemptKeys and customFees when not set", async function () {
+            // Create a topic with admin and fee schedule keys but no fee exempt keys or custom fees
+            const response = await new TopicCreateTransaction()
+                .setAdminKey(env.client.operatorPublicKey)
+                .setFeeScheduleKey(env.client.operatorPublicKey)
+                .execute(env.client);
+
+            const topicId = (await response.getReceipt(env.client)).topicId;
+
+            // Verify that fee exempt keys and custom fees are null in the topic info
+            const info = await new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            expect(info.feeExemptKeys).to.be.empty;
+            expect(info.customFees).to.be.empty;
+
+            // Update the topic without setting fee exempt keys or custom fees
+            const updateResponse = await new TopicUpdateTransaction()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            await updateResponse.getReceipt(env.client);
+
+            // Verify that fee exempt keys and custom fees are still null after update
+            const updatedInfo = await new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            expect(updatedInfo.feeExemptKeys).to.be.empty;
+            expect(updatedInfo.customFees).to.be.empty;
+        });
+
+        it("should properly update feeExemptKeys and customFees to empty list", async function () {
+            // Create fee exempt keys and custom fees for initial setup
+            const feeExemptKeys = [
+                PrivateKey.generateECDSA(),
+                PrivateKey.generateECDSA(),
+            ];
+
+            const denominatingTokenId = await createFungibleToken(env.client);
+            const customFixedFee = new CustomFixedFee()
+                .setFeeCollectorAccountId(env.client.operatorAccountId)
+                .setDenominatingTokenId(denominatingTokenId)
+                .setAmount(1);
+
+            // Create a topic with fee exempt keys and custom fees
+            const response = await new TopicCreateTransaction()
+                .setAdminKey(env.client.operatorPublicKey)
+                .setFeeScheduleKey(env.client.operatorPublicKey)
+                .setFeeExemptKeys(feeExemptKeys)
+                .addCustomFee(customFixedFee)
+                .execute(env.client);
+
+            const topicId = (await response.getReceipt(env.client)).topicId;
+
+            // Verify that fee exempt keys and custom fees are set in the topic info
+            const info = await new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            expect(info.feeExemptKeys).to.not.be.null;
+            expect(info.customFees).to.not.be.null;
+
+            // Update the topic and explicitly set fee exempt keys and custom fees to empty lists
+            const updateResponse = await new TopicUpdateTransaction()
+                .setTopicId(topicId)
+                .setFeeExemptKeys([])
+                .setCustomFees([])
+                .execute(env.client);
+
+            await updateResponse.getReceipt(env.client);
+
+            // Verify that fee exempt keys and custom fees are now empty lists
+            const updatedInfo = await new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            expect(updatedInfo.feeExemptKeys).to.be.empty;
+            expect(updatedInfo.customFees).to.be.empty;
+        });
+
+        it("should preserve feeExemptKeys and customFees when other fields are updated", async function () {
+            // Create fee exempt keys and custom fees for initial setup
+            const feeExemptKeys = [
+                PrivateKey.generateECDSA(),
+                PrivateKey.generateECDSA(),
+            ];
+
+            const denominatingTokenId = await createFungibleToken(env.client);
+            const customFixedFee = new CustomFixedFee()
+                .setFeeCollectorAccountId(env.client.operatorAccountId)
+                .setDenominatingTokenId(denominatingTokenId)
+                .setAmount(1);
+
+            // Create a topic with fee exempt keys and custom fees
+            const response = await new TopicCreateTransaction()
+                .setAdminKey(env.client.operatorPublicKey)
+                .setFeeScheduleKey(env.client.operatorPublicKey)
+                .setFeeExemptKeys(feeExemptKeys)
+                .addCustomFee(customFixedFee)
+                .execute(env.client);
+
+            const topicId = (await response.getReceipt(env.client)).topicId;
+
+            // Update a different field (topic memo) without touching fee exempt keys or custom fees
+            const updateResponse = await new TopicUpdateTransaction()
+                .setTopicId(topicId)
+                .setTopicMemo("Updated topic memo")
+                .execute(env.client);
+
+            await updateResponse.getReceipt(env.client);
+
+            // Verify that fee exempt keys and custom fees are preserved
+            const updatedInfo = await new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(env.client);
+
+            expect(updatedInfo.feeExemptKeys).to.not.be.null;
+            expect(updatedInfo.feeExemptKeys.length).to.equal(
+                feeExemptKeys.length,
+            );
+            expect(updatedInfo.customFees).to.not.be.null;
+            expect(updatedInfo.customFees.length).to.equal(1);
+            expect(updatedInfo.topicMemo).to.equal("Updated topic memo");
+        });
+    });
+
+    afterEach(async function () {
+        await env.close();
+    });
+});

--- a/test/unit/TopicUpdateTransaction.js
+++ b/test/unit/TopicUpdateTransaction.js
@@ -94,7 +94,7 @@ describe("TopicUpdateTransaction", function () {
 
             topicUpdateTransaction.clearFeeExemptKeys();
 
-            expect(topicUpdateTransaction.getFeeExemptKeys().length).to.eql(0);
+            expect(topicUpdateTransaction.getFeeExemptKeys()).to.be.null;
         });
 
         it("should set topic custom fees", function () {
@@ -208,7 +208,41 @@ describe("TopicUpdateTransaction", function () {
 
             topicUpdateTransaction.clearCustomFees();
 
-            expect(topicUpdateTransaction.getCustomFees().length).to.eql(0);
+            expect(topicUpdateTransaction.getCustomFees()).to.be.null;
+        });
+
+        it("should not include feeExemptKeyList in transaction data when feeExemptKeys is null", function () {
+            const transaction = new TopicUpdateTransaction();
+
+            // Access private _makeTransactionData method for testing purposes
+            const transactionData = transaction._makeTransactionData();
+
+            // Verify that feeExemptKeyList is null in the resulting transaction data
+            expect(transactionData.feeExemptKeyList).to.be.null;
+
+            // Create a transaction with bytes and verify data is preserved
+            const bytes = transaction.toBytes();
+            const deserialized = TopicUpdateTransaction.fromBytes(bytes);
+            const deserializedData = deserialized._makeTransactionData();
+
+            expect(deserializedData.feeExemptKeyList).to.be.null;
+        });
+
+        it("should not include customFees in transaction data when customFees is null", function () {
+            const transaction = new TopicUpdateTransaction();
+
+            // Access private _makeTransactionData method for testing purposes
+            const transactionData = transaction._makeTransactionData();
+
+            // Verify that customFees is null in the resulting transaction data
+            expect(transactionData.customFees).to.be.null;
+
+            // Create a transaction with bytes and verify data is preserved
+            const bytes = transaction.toBytes();
+            const deserialized = TopicUpdateTransaction.fromBytes(bytes);
+            const deserializedData = deserialized._makeTransactionData();
+
+            expect(deserializedData.customFees).to.be.null;
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes a bug in `TopicUpdateTransaction` related to the handling of `feeExemptKeys` and `customFees` properties when they are unset. Previously, the transaction would include empty arrays for these fields, unintentionally clearing existing values on the topic. This change ensures that unset properties are treated as `null`, preserving existing topic configurations.

## Changes

- Ensures `feeExemptKeys` and `customFees` remain `null` in the object state when not explicitly set.
- `_makeTransactionData()` now excludes `feeExemptKeyList` and `customFees` from the transaction if they are `null`.
- Serialization and deserialization preserve `null` state for these fields.
- Added unit tests to verify correct behavior and prevent regressions.

## Motivation

Unintentionally resetting topic configurations is a critical issue, especially in revenue-generating scenarios. This fix ensures users don't accidentally remove existing fees or exemptions by omitting those properties during an update.

## Related

- Closes: #3030
- [HIP-991: Permissionless revenue generating topics implementation](https://hips.hedera.com/hip/hip-991)

## Checklist

- [x] Bug fix implemented
- [x] Tests added and passing
- [x] Verified serialization and deserialization behavior