### PR TITLE
fix: Transaction receipt unhealthy error

### DIFF
--- a/src/Executable.js
+++ b/src/Executable.js
@@ -634,6 +634,14 @@ export default class Executable {
                     this._nodeAccountIds.index ===
                     this._nodeAccountIds.list.length - 1;
 
+                // Check if the request is a transaction receipt or record
+                // request to retry 10 times, because its getReceiptQuery/getRecordQuery
+                // are single node requests
+                if (isTransactionReceiptOrRecordRequest(request)) {
+                    await delayForAttempt(false, 1, 500, 500);
+                    continue;
+                }
+
                 if (isLastNode || this._nodeAccountIds.length <= 1) {
                     throw new Error(
                         `Network connectivity issue: All nodes are unhealthy. Original node list: ${this._nodeAccountIds.list.join(", ")}`,
@@ -811,6 +819,25 @@ export default class Executable {
     get logger() {
         return this._logger;
     }
+}
+
+/**
+ * Checks if the request is a transaction receipt or record request
+ *
+ * @template T
+ * @param {T} request - The request to check
+ * @returns {boolean} - True if the request is a transaction receipt or record
+ */
+function isTransactionReceiptOrRecordRequest(request) {
+    if (typeof request !== "object" || request === null) {
+        return false;
+    }
+
+    const requestType = Object.keys(request)[0];
+    return (
+        requestType === "transactionGetReceipt" ||
+        requestType === "transactionGetRecord"
+    );
 }
 
 /**

--- a/src/Executable.js
+++ b/src/Executable.js
@@ -635,10 +635,15 @@ export default class Executable {
                     this._nodeAccountIds.list.length - 1;
 
                 // Check if the request is a transaction receipt or record
-                // request to retry 10 times, because its getReceiptQuery/getRecordQuery
+                // request to retry 10 times, because getReceiptQuery/getRecordQuery
                 // are single node requests
                 if (isTransactionReceiptOrRecordRequest(request)) {
-                    await delayForAttempt(false, attempt, 500, 1000);
+                    await delayForAttempt(
+                        isLocalNode,
+                        attempt,
+                        this._minBackoff,
+                        this._maxBackoff,
+                    );
                     continue;
                 }
 
@@ -833,10 +838,8 @@ function isTransactionReceiptOrRecordRequest(request) {
         return false;
     }
 
-    const requestType = Object.keys(request)[0];
     return (
-        requestType === "transactionGetReceipt" ||
-        requestType === "transactionGetRecord"
+        "transactionGetReceipt" in request || "transactionGetRecord" in request
     );
 }
 

--- a/src/Executable.js
+++ b/src/Executable.js
@@ -638,7 +638,7 @@ export default class Executable {
                 // request to retry 10 times, because its getReceiptQuery/getRecordQuery
                 // are single node requests
                 if (isTransactionReceiptOrRecordRequest(request)) {
-                    await delayForAttempt(false, 1, 500, 500);
+                    await delayForAttempt(false, attempt, 500, 1000);
                     continue;
                 }
 

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -761,7 +761,7 @@ describe("AccountInfoMocking", function () {
             );
         });
 
-        it("should succeed when node recovery is within custom timeout window", async function () {
+        it("should succeed when node recovers within the custom retry timeout period", async function () {
             // Create and execute a transaction to get a response
             const transaction = await new FileCreateTransaction()
                 .setContents("hello 1")
@@ -773,11 +773,12 @@ describe("AccountInfoMocking", function () {
             )[0]._readmitTime = Date.now() + 100 * 10010;
 
             // Set up a timeout that makes the node healthy again after a delay
+            const randomDelay = Math.floor(Math.random() * 2001) + 1000;
             setTimeout(() => {
                 client._network._network.get(
                     transaction.nodeId.toString(),
                 )[0]._readmitTime = 0;
-            }, 4354);
+            }, randomDelay);
 
             const receipt = await transaction.getReceipt(client);
 

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -747,6 +747,9 @@ describe("AccountInfoMocking", function () {
 
             let error = null;
             try {
+                // Set min backoff to 1 to force faster retries so that the test doesn't take too long
+                client._minBackoff = 1;
+
                 await transaction.getReceipt(client);
             } catch (err) {
                 error = err;

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -7,6 +7,7 @@ import {
     FileCreateTransaction,
     TransactionId,
     TransferTransaction,
+    Status,
 } from "../../src/index.js";
 import Mocker, { UNAVAILABLE, INTERNAL, PRIVATE_KEY } from "./Mocker.js";
 import Long from "long";
@@ -687,6 +688,97 @@ describe("AccountInfoMocking", function () {
                 .execute(client);
 
             expect(info.accountId.toString()).to.be.equal("0.0.3");
+        });
+    });
+
+    describe.only("Node health recovery", function () {
+        beforeEach(async function () {
+            const responses = [
+                { response: { nodeTransactionPrecheckCode: 0 } },
+                {
+                    response: {
+                        transactionGetReceipt: {
+                            header: { nodeTransactionPrecheckCode: 0 },
+                            receipt: { status: 22 },
+                        },
+                    },
+                },
+                { response: ACCOUNT_INFO_QUERY_RESPONSE },
+            ];
+
+            ({ client, servers } = await Mocker.withResponses([responses]));
+        });
+
+        it("should successfully execute receipt query after node becomes healthy with sufficient timeout", async function () {
+            // Create and execute a transaction to get a response
+            const transaction = await new FileCreateTransaction()
+                .setContents("hello 1")
+                .execute(client);
+
+            // Make the node unhealthy
+            client._network._network.get(
+                transaction.nodeId.toString(),
+            )[0]._readmitTime = Date.now() + 100 * 10010;
+
+            // Set up a timeout that makes the node healthy again after a delay
+            setTimeout(() => {
+                client._network._network.get(
+                    transaction.nodeId.toString(),
+                )[0]._readmitTime = 0;
+            }, 2000);
+
+            // Get the receipt - this should retry and eventually succeed
+            // Default timeout should be enough
+            const receipt = await transaction.getReceipt(client);
+
+            expect(receipt.status).to.equal(Status.Success);
+        });
+
+        it("should fail when node recovery takes longer than the custom retry timeout", async function () {
+            // Create and execute a transaction to get a response
+            const transaction = await new FileCreateTransaction()
+                .setContents("hello 1")
+                .execute(client);
+
+            // Make the node unhealthy
+            client._network._network.get(
+                transaction.nodeId.toString(),
+            )[0]._readmitTime = Date.now() + 100 * 10010;
+
+            let error = null;
+            try {
+                await transaction.getReceipt(client);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).to.not.be.null;
+            expect(error.message).to.equal(
+                "max attempts of 10 was reached for request with last error being: ",
+            );
+        });
+
+        it("should succeed when node recovery is within custom timeout window", async function () {
+            // Create and execute a transaction to get a response
+            const transaction = await new FileCreateTransaction()
+                .setContents("hello 1")
+                .execute(client);
+
+            // Make the node unhealthy
+            client._network._network.get(
+                transaction.nodeId.toString(),
+            )[0]._readmitTime = Date.now() + 100 * 10010;
+
+            // Set up a timeout that makes the node healthy again after a delay
+            setTimeout(() => {
+                client._network._network.get(
+                    transaction.nodeId.toString(),
+                )[0]._readmitTime = 0;
+            }, 4354);
+
+            const receipt = await transaction.getReceipt(client);
+
+            expect(receipt.status).to.equal(Status.Success);
         });
     });
 });

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -691,7 +691,7 @@ describe("AccountInfoMocking", function () {
         });
     });
 
-    describe.only("Node health recovery", function () {
+    describe("Node health recovery", function () {
         beforeEach(async function () {
             const responses = [
                 { response: { nodeTransactionPrecheckCode: 0 } },


### PR DESCRIPTION
**Description**:
This PR fixes execution of `getReceiptQuery` and `getRecordQuery` that are single-node requests, meaning they rely on one specific node to succeed. If that node is unhealthy, these queries can fail with errors such as "Network connectivity issue: All nodes are unhealthy." To handle this, we retry the request up to 10 times before failing with a delay.

**Related issue(s)**:
#2926 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
