### PR TITLE
feat: enable hip-1021

### DIFF
--- a/src/topic/TopicCreateTransaction.js
+++ b/src/topic/TopicCreateTransaction.js
@@ -475,6 +475,20 @@ export default class TopicCreateTransaction extends Transaction {
 
     /**
      * @override
+     * @param {?import("../client/Client.js").default<Channel, *>} client
+     * @returns {this}
+     */
+    freezeWith(client) {
+        if (!this._autoRenewAccountId && this.transactionId?.accountId) {
+            this.setAutoRenewAccountId(this.transactionId?.accountId);
+        } else if (!this._autoRenewAccountId && client?.operatorAccountId) {
+            this.setAutoRenewAccountId(client.operatorAccountId);
+        }
+        return super.freezeWith(client);
+    }
+
+    /**
+     * @override
      * @internal
      * @param {Channel} channel
      * @param {HieroProto.proto.ITransaction} request

--- a/test/integration/TokenUpdateIntegrationTest.js
+++ b/test/integration/TokenUpdateIntegrationTest.js
@@ -162,11 +162,13 @@ describe("TokenUpdate", function () {
         expect(info.freezeKey.toString()).to.eql(key2.publicKey.toString());
         expect(info.wipeKey.toString()).to.eql(key3.publicKey.toString());
         expect(info.supplyKey.toString()).to.eql(key4.publicKey.toString());
-        expect(info.autoRenewAccountId).to.be.not.null;
+        expect(info.autoRenewAccountId.toString()).to.be.eql(
+            operatorId.toString(),
+        );
         expect(info.defaultFreezeStatus).to.be.false;
         expect(info.defaultKycStatus).to.be.false;
         expect(info.isDeleted).to.be.false;
-        expect(info.autoRenewAccountId).to.be.not.null;
+        expect(info.autoRenewPeriod).to.be.not.null;
         expect(info.expirationTime).to.be.not.null;
 
         await (

--- a/test/integration/TopicCreateIntegrationTest.js
+++ b/test/integration/TopicCreateIntegrationTest.js
@@ -2,6 +2,7 @@ import {
     AccountBalanceQuery,
     CustomFeeLimit,
     CustomFixedFee,
+    Hbar,
     PrivateKey,
     PublicKey,
     Status,
@@ -11,6 +12,7 @@ import {
     TopicInfoQuery,
     TopicMessageSubmitTransaction,
     TopicUpdateTransaction,
+    TransactionId,
     TransferTransaction,
 } from "../../src/exports.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
@@ -37,7 +39,6 @@ describe("TopicCreate", function () {
         const response = await new TopicCreateTransaction()
             .setAdminKey(operatorKey)
             .setSubmitKey(operatorKey)
-            .setAutoRenewAccountId(operatorId)
             .execute(env.client);
 
         const topic = (await response.getReceipt(env.client)).topicId;
@@ -80,22 +81,23 @@ describe("TopicCreate", function () {
         expect(info.sequenceNumber.toInt()).to.eql(0);
         expect(info.adminKey).to.be.null;
         expect(info.submitKey).to.be.null;
-        /*
         // as per HIP-1021 autoRenewAccountId should be set to the operator account id
         expect(info.autoRenewAccountId.toString()).to.equal(
             env.client.operatorAccountId.toString(),
         );
-        */
-        expect(info.autoRenewAccountId).to.be.null;
         expect(info.autoRenewPeriod.seconds.toInt()).to.be.eql(7776000);
         expect(info.expirationTime).to.be.not.null;
     });
-    /*    
+
     it("should set autorenew account from transaction ID", async function () {
-        const accountKey = PrivateKey.generateECDSA();
-        const { accountId } = await createAccount(env.client, (transaction) => {
-            transaction.setKey(accountKey);
-        });
+        // Create a new account with 10 Hbar
+
+        const { accountId, newKey: accountKey } = await createAccount(
+            env.client,
+            (tx) => {
+                tx.setInitialBalance(new Hbar(10));
+            },
+        );
 
         // Create transaction ID with the new account
         const txId = TransactionId.generate(accountId);
@@ -124,7 +126,7 @@ describe("TopicCreate", function () {
             accountId.toString(),
         );
     });
-    */
+
     describe("HIP-991: Permissionless revenue generating topics", function () {
         it("creates and updates revenue generating topic", async function () {
             const feeExemptKeys = [

--- a/test/integration/TopicInfoIntegrationTest.js
+++ b/test/integration/TopicInfoIntegrationTest.js
@@ -65,11 +65,9 @@ describe("TopicInfo", function () {
         expect(info.sequenceNumber.toInt()).to.eql(0);
         expect(info.adminKey).to.be.null;
         expect(info.submitKey).to.be.null;
-        /*
         expect(info.autoRenewAccountId.toString()).to.be.eql(
             env.operatorId.toString(),
         );
-        */
         expect(info.autoRenewPeriod.seconds.toInt()).to.be.eql(7776000);
         expect(info.expirationTime).to.be.not.null;
     });


### PR DESCRIPTION
## **Description**:
This PR reintroduces and finalizes support for [HIP-1021](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-1021.md), which was previously reverted due to the changes not yet being live on mainnet.

Now that the feature is available on mainnet, we're enabling HIP-1021 with the required SDK logic.

**Related issue(s)**: https://github.com/hiero-ledger/hiero-sdk-js/issues/3042

Fixes # https://github.com/hiero-ledger/hiero-sdk-js/issues/3042

## **Background**:
HIP-1021 introduces functionality that requires:

The autoRenewAccountId for TopicCreateTransaction to be automatically set to the fee payer if the user does not explicitly provide one.

This logic must be injected at the correct stage of the execution workflow, ensuring proper fee assignment and predictable behavior.

**Original issue**: https://github.com/hiero-ledger/hiero-sdk-js/issues/2879
**Original PR**: https://github.com/hiero-ledger/hiero-sdk-js/pull/2890 by @ivaylonikolov7 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
