### PR TITLE
fix: `isLongZeroAddress` for non-zero shards and realms

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -119,7 +119,7 @@ export function isStringOrUint8Array(variable) {
 }
 
 /**
- * Takes an address as `Uint8Array` and returns whether or not this represents a Hedera account ID
+ * Takes an address as `Uint8Array` and returns whether or not this represents a Hiero account ID
  * converted to a solidity address format (rather than a native Ethereum address).
  *
  * An account ID in solidity address format has:
@@ -128,14 +128,14 @@ export function isStringOrUint8Array(variable) {
  * - Last 8 bytes (12-19) = account number
  *
  * This function checks if the middle bytes (4-11) follow the expected pattern
- * for a Hedera realm number, which helps differentiate from Ethereum addresses.
+ * for a Hiero realm number, which helps differentiate from Ethereum addresses.
  *
  * @param {Uint8Array} address - The 20-byte address to check
- * @returns {boolean} - True if this represents a Hedera account ID, false if it's likely an Ethereum address
+ * @returns {boolean} - True if this represents a Hiero account ID, false if it's likely an Ethereum address
  */
 export function isLongZeroAddress(address) {
     // Check if the realm bytes (4-11) follow expected pattern
-    // In a Hedera account ID, these bytes will typically have leading zeros
+    // In a Hiero account ID, these bytes will typically have leading zeros
     // and represent a valid realm number
     let hasNonZeroBytes = false;
     for (let i = 4; i < 8; i++) {
@@ -146,7 +146,7 @@ export function isLongZeroAddress(address) {
     }
 
     // If first 4 bytes are zero and no non-zero bytes found in first half of realm,
-    // this is likely a Hedera account ID
+    // this is likely a Hiero account ID
     return !hasNonZeroBytes;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -119,18 +119,35 @@ export function isStringOrUint8Array(variable) {
 }
 
 /**
- * Takes an address as `Uint8Array` and returns whether or not this is a long-zero address
+ * Takes an address as `Uint8Array` and returns whether or not this represents a Hedera account ID
+ * converted to a solidity address format (rather than a native Ethereum address).
  *
- * @param {Uint8Array} address
- * @returns {boolean}
+ * An account ID in solidity address format has:
+ * - First 4 bytes (0-3) = shard
+ * - Next 8 bytes (4-11) = realm
+ * - Last 8 bytes (12-19) = account number
+ *
+ * This function checks if the middle bytes (4-11) follow the expected pattern
+ * for a Hedera realm number, which helps differentiate from Ethereum addresses.
+ *
+ * @param {Uint8Array} address - The 20-byte address to check
+ * @returns {boolean} - True if this represents a Hedera account ID, false if it's likely an Ethereum address
  */
 export function isLongZeroAddress(address) {
-    for (let i = 0; i < 12; i++) {
-        if (address[i] != 0) {
-            return false;
+    // Check if the realm bytes (4-11) follow expected pattern
+    // In a Hedera account ID, these bytes will typically have leading zeros
+    // and represent a valid realm number
+    let hasNonZeroBytes = false;
+    for (let i = 4; i < 8; i++) {
+        if (address[i] !== 0) {
+            hasNonZeroBytes = true;
+            break;
         }
     }
-    return true;
+
+    // If first 4 bytes are zero and no non-zero bytes found in first half of realm,
+    // this is likely a Hedera account ID
+    return !hasNonZeroBytes;
 }
 
 /**

--- a/test/unit/AccountId.js
+++ b/test/unit/AccountId.js
@@ -322,11 +322,8 @@ describe("AccountId", function () {
             );
         }
     });
-});
-
-describe("isLongZeroAddress", function () {
-    it("should identify Hedera account IDs with zero shard and realm", function () {
-        // Create a typical Hedera account address with zeros in shard and realm
+    it("should identify Hiero account IDs with zero shard and realm", function () {
+        // Create a typical Hiero account address with zeros in shard and realm
         const address = new Uint8Array(20);
         // Set some non-zero bytes in the account number portion (last 8 bytes)
         address[12] = 1;
@@ -335,7 +332,7 @@ describe("isLongZeroAddress", function () {
         expect(isLongZeroAddress(address)).to.be.true;
     });
 
-    it("should identify Hedera account IDs with non-zero shard", function () {
+    it("should identify Hiero account IDs with non-zero shard", function () {
         const address = new Uint8Array(20);
         // Set non-zero shard (first 4 bytes)
         address[0] = 1;
@@ -354,7 +351,7 @@ describe("isLongZeroAddress", function () {
         expect(isLongZeroAddress(bytes)).to.be.false;
     });
 
-    it("should identify Hedera account IDs with large realm values", function () {
+    it("should identify Hiero account IDs with large realm values", function () {
         const accountId = new AccountId(1, 50000, 3);
         const solAddress = accountId.toSolidityAddress();
         const bytes = hex.decode(solAddress);
@@ -370,7 +367,7 @@ describe("isLongZeroAddress", function () {
 
 describe("fromEvmAddress", function () {
     it("should handle long-zero format addresses", function () {
-        // Create an address that represents a Hedera account ID (0.0.5)
+        // Create an address that represents a Hiero account ID (0.0.5)
         const accountId = new AccountId(0, 0, 5);
         const solAddress = accountId.toSolidityAddress();
 
@@ -402,7 +399,7 @@ describe("fromEvmAddress", function () {
     });
 
     it("should handle non-zero shard and realm with long-zero format", function () {
-        // Create an address that represents a Hedera account ID (1.2.5)
+        // Create an address that represents a Hiero account ID (1.2.5)
         const accountId = new AccountId(1, 2, 5);
         const solAddress = accountId.toSolidityAddress();
 

--- a/test/unit/AccountId.js
+++ b/test/unit/AccountId.js
@@ -363,9 +363,6 @@ describe("AccountId", function () {
         const address = new Uint8Array(20); // All bytes are 0
         expect(isLongZeroAddress(address)).to.be.true;
     });
-});
-
-describe("fromEvmAddress", function () {
     it("should handle long-zero format addresses", function () {
         // Create an address that represents a Hiero account ID (0.0.5)
         const accountId = new AccountId(0, 0, 5);

--- a/test/unit/ContractId.js
+++ b/test/unit/ContractId.js
@@ -70,4 +70,82 @@ describe("ContractId", function () {
 
         expect(contractId).to.deep.equal(contractIdFromAddress);
     });
+    it("should handle long-zero format addresses", function () {
+        // Create a contract address that represents a Hedera contract (0.0.5)
+        const contractId = new ContractId(0, 0, 5);
+        const solAddress = contractId.toSolidityAddress();
+
+        // Convert it back using fromEvmAddress
+        const result = ContractId.fromEvmAddress(0, 0, solAddress);
+
+        // Should reconstruct the original contract ID
+        expect(result.shard.toNumber()).to.equal(0);
+        expect(result.realm.toNumber()).to.equal(0);
+        expect(result.num.toNumber()).to.equal(5);
+        expect(result.evmAddress).to.be.null;
+    });
+
+    it("should handle native EVM addresses", function () {
+        const evmAddress = "742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        const shard = 1;
+        const realm = 2;
+
+        const result = ContractId.fromEvmAddress(shard, realm, evmAddress);
+
+        // For EVM addresses, should store shard/realm and keep the EVM address
+        expect(result.shard.toNumber()).to.equal(shard);
+        expect(result.realm.toNumber()).to.equal(realm);
+        expect(result.num.toNumber()).to.equal(0);
+        expect(result.evmAddress).to.not.be.null;
+        expect(hex.encode(result.evmAddress)).to.equal(
+            evmAddress.toLowerCase(),
+        );
+    });
+
+    it("should handle non-zero shard and realm with long-zero format", function () {
+        // Create a contract address that represents a Hiero contract (1.2.5)
+        const contractId = new ContractId(1, 2, 5);
+        const solAddress = contractId.toSolidityAddress();
+
+        // Convert it back using fromEvmAddress
+        const result = ContractId.fromEvmAddress(1, 2, solAddress);
+
+        // Should reconstruct the original contract ID
+        expect(result.shard.toNumber()).to.equal(1);
+        expect(result.realm.toNumber()).to.equal(2);
+        expect(result.num.toNumber()).to.equal(5);
+        expect(result.evmAddress).to.be.null;
+    });
+
+    it("should handle addresses with 0x prefix", function () {
+        const evmAddress = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        const result = ContractId.fromEvmAddress(1, 2, evmAddress);
+
+        expect(hex.encode(result.evmAddress)).to.equal(
+            evmAddress.slice(2).toLowerCase(),
+        );
+    });
+
+    it("should handle very large contract numbers in long-zero format", function () {
+        // Create a contract with a large number
+        const contractId = new ContractId(0, 0, Long.fromString("123456789"));
+        const solAddress = contractId.toSolidityAddress();
+
+        const result = ContractId.fromEvmAddress(0, 0, solAddress);
+
+        expect(result.num.toString()).to.equal("123456789");
+        expect(result.evmAddress).to.be.null;
+    });
+
+    it("should handle negative shard/realm values", function () {
+        const evmAddress = "742d35Cc6634C0532925a3b844Bc454e4438f44e";
+
+        expect(() => {
+            ContractId.fromEvmAddress(-1, 0, evmAddress);
+        }).to.throw();
+
+        expect(() => {
+            ContractId.fromEvmAddress(0, -1, evmAddress);
+        }).to.throw();
+    });
 });

--- a/test/unit/ContractId.js
+++ b/test/unit/ContractId.js
@@ -71,7 +71,7 @@ describe("ContractId", function () {
         expect(contractId).to.deep.equal(contractIdFromAddress);
     });
     it("should handle long-zero format addresses", function () {
-        // Create a contract address that represents a Hedera contract (0.0.5)
+        // Create a contract address that represents a Hiero contract (0.0.5)
         const contractId = new ContractId(0, 0, 5);
         const solAddress = contractId.toSolidityAddress();
 


### PR DESCRIPTION
**Description**:
WIP

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
