### PR TITLE
feat: expose signable transaction body bytes for HSM signing

### DIFF
--- a/examples/sign-tx-body-bytes-with-hsm.js
+++ b/examples/sign-tx-body-bytes-with-hsm.js
@@ -129,6 +129,7 @@ async function main() {
         /**
          * Example 2: Multi-Node Batched Transaction
          * Note: This is example makes sense only in a multi-node environment (testnet, mainnet, etc).
+         * Node Accounts will be 3 on testnet, 9 on mainnet and 1 on localhost.
          *
          * This example demonstrates how to sign transaction body bytes
          * using an HSM for a multi-node batched transaction.
@@ -150,17 +151,16 @@ async function main() {
 
         console.log(`Created file with ID: ${fileId.toString()}`);
 
-        const allAvailableNodeAccountIds = /** @type {AccountId[]} */ (
-            Object.values(client.network)
-        );
-
         const multiNodeTx = new FileAppendTransaction()
             .setFileId(fileId)
             .setContents(bigContents)
-            .setNodeAccountIds(allAvailableNodeAccountIds)
             .setMaxTransactionFee(new Hbar(5))
             .setTransactionId(TransactionId.generate(senderId))
             .freezeWith(client);
+
+        const allAvailableNodeAccountIds = /** @type {AccountId[]} */ (
+            Object.values(client.network)
+        );
 
         console.log(
             `Signing transaction with HSM for nodes: ${allAvailableNodeAccountIds

--- a/examples/sign-tx-body-bytes-with-hsm.js
+++ b/examples/sign-tx-body-bytes-with-hsm.js
@@ -13,53 +13,7 @@ import {
 } from "@hashgraph/sdk";
 import dotenv from "dotenv";
 
-const bigContents = `
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur aliquam augue sem, ut mattis dui laoreet a. Curabitur consequat est euismod, scelerisque metus et, tristique dui. Nulla commodo mauris ut faucibus ultricies. Quisque venenatis nisl nec augue tempus, at efficitur elit eleifend. Duis pharetra felis metus, sed dapibus urna vehicula id. Duis non venenatis turpis, sit amet ornare orci. Donec non interdum quam. Sed finibus nunc et risus finibus, non sagittis lorem cursus. Proin pellentesque tempor aliquam. Sed congue nisl in enim bibendum, condimentum vehicula nisi feugiat.
-
-Suspendisse non sodales arcu. Suspendisse sodales, lorem ac mollis blandit, ipsum neque porttitor nulla, et sodales arcu ante fermentum tellus. Integer sagittis dolor sed augue fringilla accumsan. Cras vitae finibus arcu, sit amet varius dolor. Etiam id finibus dolor, vitae luctus velit. Proin efficitur augue nec pharetra accumsan. Aliquam lobortis nisl diam, vel fermentum purus finibus id. Etiam at finibus orci, et tincidunt turpis. Aliquam imperdiet congue lacus vel facilisis. Phasellus id magna vitae enim dapibus vestibulum vitae quis augue. Morbi eu consequat enim. Maecenas neque nulla, pulvinar sit amet consequat sed, tempor sed magna. Mauris lacinia sem feugiat faucibus aliquet. Etiam congue non turpis at commodo. Nulla facilisi.
-
-Nunc velit turpis, cursus ornare fringilla eu, lacinia posuere leo. Mauris rutrum ultricies dui et suscipit. Curabitur in euismod ligula. Curabitur vitae faucibus orci. Phasellus volutpat vestibulum diam sit amet vestibulum. In vel purus leo. Nulla condimentum lectus vestibulum lectus faucibus, id lobortis eros consequat. Proin mollis libero elit, vel aliquet nisi imperdiet et. Morbi ornare est velit, in vehicula nunc malesuada quis. Donec vehicula convallis interdum.
-
-Integer pellentesque in nibh vitae aliquet. Ut at justo id libero dignissim hendrerit. Interdum et malesuada fames ac ante ipsum primis in faucibus. Praesent quis ornare lectus. Nam malesuada non diam quis cursus. Phasellus a libero ligula. Suspendisse ligula elit, congue et nisi sit amet, cursus euismod dolor. Morbi aliquam, nulla a posuere pellentesque, diam massa ornare risus, nec eleifend neque eros et elit.
-
-Pellentesque a sodales dui. Sed in efficitur ante. Duis eget volutpat elit, et ornare est. Nam felis dolor, placerat mattis diam id, maximus lobortis quam. Sed pellentesque lobortis sem sed placerat. Pellentesque augue odio, molestie sed lectus sit amet, congue volutpat massa. Quisque congue consequat nunc id fringilla. Duis semper nulla eget enim venenatis dapibus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque varius turpis nibh, sit amet malesuada mauris malesuada quis. Vivamus dictum egestas placerat. Vivamus id augue elit.
-
-Cras fermentum volutpat eros, vitae euismod lorem viverra nec. Donec lectus augue, porta eleifend odio sit amet, condimentum rhoncus urna. Nunc sed odio velit. Morbi non cursus odio, eget imperdiet erat. Nunc rhoncus massa non neque volutpat, sit amet faucibus ante congue. Phasellus nec lorem vel leo accumsan lobortis. Maecenas id ligula bibendum purus suscipit posuere ac eget diam. Nam in quam pretium, semper erat auctor, iaculis odio. Maecenas placerat, nisi ac elementum tempor, felis nulla porttitor orci, ac rhoncus diam justo in elit. Etiam lobortis fermentum ligula in tincidunt. Donec quis vestibulum nunc. Sed eros diam, interdum in porta lobortis, gravida eu magna. Donec diam purus, finibus et sollicitudin quis, fringilla nec nisi. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur ultricies sagittis dapibus. Etiam ullamcorper aliquet libero, eu venenatis mauris suscipit id.
-
-Ut interdum eleifend sem, vel bibendum ipsum volutpat eget. Nunc ac dignissim augue. Aliquam ornare aliquet magna id dignissim. Vestibulum velit sem, lacinia eu rutrum in, rhoncus vitae mauris. Pellentesque scelerisque pulvinar mauris non cursus. Integer id dolor porta, bibendum sem vel, pretium tortor. Fusce a nisi convallis, interdum quam condimentum, suscipit dolor. Sed magna diam, efficitur non nunc in, tincidunt varius mi. Aliquam ullamcorper nulla eu fermentum bibendum. Vivamus a felis pretium, hendrerit enim vitae, hendrerit leo. Suspendisse lacinia lectus a diam consectetur suscipit. Aenean hendrerit nisl sed diam venenatis pellentesque. Nullam egestas lectus a consequat pharetra. Vivamus ornare tellus auctor, facilisis lacus id, feugiat dui. Nam id est ut est rhoncus varius.
-
-Aenean vel vehicula erat. Aenean gravida risus vitae purus sodales, quis dictum enim porta. Ut elit elit, fermentum sed posuere non, accumsan eu justo. Integer porta malesuada quam, et elementum massa suscipit nec. Donec in elit diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis suscipit vel ante volutpat vestibulum.
-
-Pellentesque ex arcu, euismod et sapien ut, vulputate suscipit enim. Donec mattis sagittis augue, et mattis lacus. Cras placerat consequat lorem sed luctus. Nam suscipit aliquam sem ac imperdiet. Mauris a semper augue, pulvinar fringilla magna. Integer pretium massa non risus commodo hendrerit. Sed dictum libero id erat sodales mattis. Etiam auctor dolor lectus, ut sagittis enim lobortis vitae. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Curabitur nec orci lobortis, cursus risus eget, sollicitudin massa. Integer vel tincidunt mi, id eleifend quam. Nullam facilisis nisl eu mauris congue, vitae euismod nisi malesuada. Vivamus sit amet urna et libero sagittis dictum.
-
-In hac habitasse platea dictumst. Aliquam erat volutpat. Ut dictum, mi a viverra venenatis, mi urna pulvinar nisi, nec gravida lectus diam eget urna. Ut dictum sit amet nisl ut dignissim. Sed sed mauris scelerisque, efficitur augue in, vulputate turpis. Proin dolor justo, bibendum et sollicitudin feugiat, imperdiet sed mi. Sed elementum vitae massa vel lobortis. Cras vitae massa sit amet libero dictum tempus.
-
-Vivamus ut mauris lectus. Curabitur placerat ornare scelerisque. Cras malesuada nunc quis tortor pretium bibendum vel sed dui. Cras lobortis nibh eu erat blandit, sit amet consequat neque fermentum. Phasellus imperdiet molestie tristique. Cras auctor purus erat, id mollis ligula porttitor eget. Mauris porta pharetra odio et finibus. Suspendisse eu est a ligula bibendum cursus. Mauris ac laoreet libero. Nullam volutpat sem quis rhoncus gravida.
-
-Donec malesuada lacus ac iaculis cursus. Sed sem orci, feugiat ac est ut, ultricies posuere nisi. Suspendisse potenti. Phasellus ut ultricies purus. Etiam sem tortor, fermentum quis aliquam eget, consequat ut nulla. Aliquam dictum metus in mi fringilla, vel gravida nulla accumsan. Cras aliquam eget leo vel posuere. Vivamus vitae malesuada nunc. Morbi placerat magna mi, id suscipit lacus auctor quis. Nam at lorem vel odio finibus fringilla ut ac velit. Donec laoreet at nibh quis vehicula.
-
-Fusce ac tristique nisi. Donec leo nisi, consectetur at tellus sit amet, consectetur ultrices dui. Quisque gravida mollis tempor. Maecenas semper, sapien ut dignissim feugiat, massa enim viverra dolor, non varius eros nulla nec felis. Nunc massa lacus, ornare et feugiat id, bibendum quis purus. Praesent viverra elit sit amet purus consectetur venenatis. Maecenas nibh risus, elementum sit amet enim sagittis, ultrices malesuada lectus. Vivamus non felis ante. Ut vulputate ex arcu. Aliquam porta gravida porta. Aliquam eros leo, malesuada quis eros non, maximus tristique neque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam ligula orci, mollis vel luctus nec, venenatis vitae est. Fusce rutrum convallis nisi.
-
-Nunc laoreet eget nibh in feugiat. Pellentesque nec arcu cursus, gravida dolor a, pellentesque nisi. Praesent vel justo blandit, placerat risus eget, consectetur orci. Sed maximus metus mi, ut euismod augue ultricies in. Nunc id risus hendrerit, aliquet lorem nec, congue justo. Vestibulum vel nunc ac est euismod mattis ac vitae nulla. Donec blandit luctus mauris, sit amet bibendum dui egestas et. Aenean nec lorem nec elit ornare rutrum nec eget ligula. Fusce a ipsum vitae neque elementum pharetra. Pellentesque ullamcorper ullamcorper libero, vitae porta sem sagittis vel. Interdum et malesuada fames ac ante ipsum primis in faucibus.
-
-Duis at massa sit amet risus pellentesque varius sit amet vitae eros. Cras tempor aliquet sapien, vehicula varius neque volutpat et. Donec purus nibh, pellentesque ut lobortis nec, ultricies ultricies nisl. Sed accumsan ut dui sit amet vulputate. Suspendisse eu facilisis massa, a hendrerit mauris. Nulla elementum molestie tincidunt. Donec mi justo, ornare vel tempor id, gravida et orci. Nam molestie erat nec nisi bibendum accumsan. Duis vitae tempor ante. Morbi congue mauris vel sagittis facilisis. Vivamus vehicula odio orci, a tempor nibh euismod in. Proin mattis, nibh at feugiat porta, purus velit posuere felis, quis volutpat sapien dui vel odio. Nam fermentum sem nec euismod aliquet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam erat volutpat.
-
-Mauris congue lacus tortor. Pellentesque arcu eros, accumsan imperdiet porttitor vitae, mattis nec justo. Nullam ac aliquam mauris. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse potenti. Fusce accumsan tempus felis a sagittis. Maecenas et velit odio. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aliquam eros lacus, volutpat non urna sed, tincidunt ullamcorper elit. Sed sit amet gravida libero. In varius mi vel diam sollicitudin mollis.
-
-Aenean varius, diam vitae hendrerit feugiat, libero augue ultrices odio, eget consequat sem tellus eu nisi. Nam dapibus enim et auctor sollicitudin. Nunc iaculis eros orci, ac accumsan eros malesuada ut. Ut semper augue felis, nec sodales lorem consectetur non. Cras gravida eleifend est, et sagittis eros imperdiet congue. Fusce id tellus dapibus nunc scelerisque tempus. Donec tempor placerat libero, in commodo nisi bibendum eu. Donec id eros non est sollicitudin luctus. Duis bibendum bibendum tellus nec viverra. Aliquam non faucibus ex, nec luctus dui. Curabitur efficitur varius urna non dignissim. Suspendisse elit elit, ultrices in elementum eu, tempor at magna.
-
-Nunc in purus sit amet mi laoreet pulvinar placerat eget sapien. Donec vel felis at dui ultricies euismod quis vel neque. Donec tincidunt urna non eros pretium blandit. Nullam congue tincidunt condimentum. Curabitur et libero nibh. Proin ultricies risus id imperdiet scelerisque. Suspendisse purus mi, viverra vitae risus ut, tempus tincidunt enim. Ut luctus lobortis nisl, eget venenatis tortor cursus non. Mauris finibus nisl quis gravida ultricies. Fusce elementum lacus sit amet nunc congue, in porta nulla tincidunt.
-
-Mauris ante risus, imperdiet blandit posuere in, blandit eu ipsum. Integer et auctor arcu. Integer quis elementum purus. Nunc in ultricies nisl, sed rutrum risus. Suspendisse venenatis eros nec lorem rhoncus, in scelerisque velit condimentum. Etiam condimentum quam felis, in elementum odio mattis et. In ut nibh porttitor, hendrerit tellus vel, luctus magna. Vestibulum et ligula et dolor pellentesque porta. Aenean efficitur porta massa et bibendum. Nulla vehicula sem in risus volutpat, a eleifend elit maximus.
-
-Proin orci lorem, auctor a felis eu, pretium lobortis nulla. Phasellus aliquam efficitur interdum. Sed sit amet velit rutrum est dictum facilisis. Duis cursus enim at nisl tincidunt, eu molestie elit vehicula. Cras pellentesque nisl id enim feugiat fringilla. In quis tincidunt neque. Nam eu consectetur dolor. Ut id interdum mauris. Mauris nunc tortor, placerat in tempor ut, vestibulum eu nisl. Integer vel dapibus ipsum. Nunc id erat pulvinar, tincidunt magna id, condimentum massa. Pellentesque consequat est eget odio placerat vehicula. Etiam augue neque, sagittis non leo eu, tristique scelerisque dui. Ut dui urna, blandit quis urna ac, tincidunt tristique turpis.
-
-Suspendisse venenatis rhoncus ligula ultrices condimentum. In id laoreet eros. Suspendisse suscipit fringilla leo id euismod. Sed in quam libero. Ut at ligula tellus. Sed tristique gravida dui, at egestas odio aliquam iaculis. Praesent imperdiet velit quis nibh consequat, quis pretium sem sagittis. Donec tortor ex, congue sit amet pulvinar ac, rutrum non est. Praesent ipsum magna, venenatis sit amet vulputate id, eleifend ac ipsum.
-
-In consequat, nisi iaculis laoreet elementum, massa mauris varius nisi, et porta nisi velit at urna. Maecenas sit amet aliquet eros, a rhoncus nisl. Maecenas convallis enim nunc. Morbi purus nisl, aliquam ac tincidunt sed, mattis in augue. Quisque et elementum quam, vitae maximus orci. Suspendisse hendrerit risus nec vehicula placerat. Nulla et lectus nunc. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
-
-Etiam ut sodales ex. Nulla luctus, magna eu scelerisque sagittis, nibh quam consectetur neque, non rutrum dolor metus nec ex. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed egestas augue elit, sollicitudin accumsan massa lobortis ac. Curabitur placerat, dolor a aliquam maximus, velit ipsum laoreet ligula, id ullamcorper lacus nibh eget nisl. Donec eget lacus venenatis enim consequat auctor vel in.
-`;
+const bigContents = Array(1000).fill("Lorem ipsum dolor sit amet. ").join("");
 
 dotenv.config();
 
@@ -143,26 +97,21 @@ async function main() {
             singleNodeTx.signableNodeBodyBytesList;
         const singleNodeSignatureMap = new SignatureMap();
 
-        // Sign the transaction body bytes using HSM
-        for (const {
-            nodeAccountId,
-            transactionId,
-            signableTransactionBodyBytes,
-        } of singleNodeSignableBodyBytesList) {
-            const signature = await hsmSign(
-                senderPrivateKey,
-                signableTransactionBodyBytes,
-            );
+        const signableBodyBytes = singleNodeSignableBodyBytesList[0];
 
-            singleNodeSignatureMap.addSignature(
-                nodeAccountId,
-                transactionId,
-                senderPrivateKey.publicKey,
-                signature,
-            );
-        }
+        const signature = await hsmSign(
+            senderPrivateKey,
+            signableBodyBytes.signableTransactionBodyBytes,
+        );
 
-        // Add the signatures to the transaction
+        singleNodeSignatureMap.addSignature(
+            signableBodyBytes.nodeAccountId,
+            signableBodyBytes.transactionId,
+            senderPrivateKey.publicKey,
+            signature,
+        );
+
+        // Add the signature map to the transaction
         singleNodeTx.addSignature(
             senderPrivateKey.publicKey,
             singleNodeSignatureMap,
@@ -201,24 +150,20 @@ async function main() {
 
         console.log(`Created file with ID: ${fileId.toString()}`);
 
-        const allAvailableNodeAccountIds = Object.values(client.network);
-
-        const nodeAccountIds = [
-            /** @type {AccountId} */ (allAvailableNodeAccountIds[0]),
-            /** @type {AccountId} */ (allAvailableNodeAccountIds[1]),
-            /** @type {AccountId} */ (allAvailableNodeAccountIds[2]),
-        ];
+        const allAvailableNodeAccountIds = /** @type {AccountId[]} */ (
+            Object.values(client.network)
+        );
 
         const multiNodeTx = new FileAppendTransaction()
             .setFileId(fileId)
             .setContents(bigContents)
-            .setNodeAccountIds(nodeAccountIds)
+            .setNodeAccountIds(allAvailableNodeAccountIds)
             .setMaxTransactionFee(new Hbar(5))
             .setTransactionId(TransactionId.generate(senderId))
             .freezeWith(client);
 
         console.log(
-            `Signing transaction with HSM for nodes: ${nodeAccountIds
+            `Signing transaction with HSM for nodes: ${allAvailableNodeAccountIds
                 .map((id) => id.toString())
                 .join(", ")}`,
         );
@@ -228,7 +173,7 @@ async function main() {
             multiNodeTx.signableNodeBodyBytesList;
         const multiNodeSignatureMap = new SignatureMap();
 
-        // Sign the transaction body bytes for each node using HSM
+        // Sign the transaction body bytes for each node using HSM and add the signatures to the signature map
         for (const {
             nodeAccountId,
             transactionId,
@@ -247,7 +192,7 @@ async function main() {
             );
         }
 
-        // Add the signatures to the transaction
+        // Add the signature map to the transaction
         multiNodeTx.addSignature(
             senderPrivateKey.publicKey,
             multiNodeSignatureMap,

--- a/examples/sign-tx-body-bytes-with-hsm.js
+++ b/examples/sign-tx-body-bytes-with-hsm.js
@@ -1,0 +1,279 @@
+import {
+    AccountCreateTransaction,
+    AccountId,
+    Hbar,
+    PrivateKey,
+    Client,
+    SignatureMap,
+    TransferTransaction,
+    TransactionId,
+    FileCreateTransaction,
+    FileAppendTransaction,
+    FileContentsQuery,
+} from "@hashgraph/sdk";
+import dotenv from "dotenv";
+
+const bigContents = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur aliquam augue sem, ut mattis dui laoreet a. Curabitur consequat est euismod, scelerisque metus et, tristique dui. Nulla commodo mauris ut faucibus ultricies. Quisque venenatis nisl nec augue tempus, at efficitur elit eleifend. Duis pharetra felis metus, sed dapibus urna vehicula id. Duis non venenatis turpis, sit amet ornare orci. Donec non interdum quam. Sed finibus nunc et risus finibus, non sagittis lorem cursus. Proin pellentesque tempor aliquam. Sed congue nisl in enim bibendum, condimentum vehicula nisi feugiat.
+
+Suspendisse non sodales arcu. Suspendisse sodales, lorem ac mollis blandit, ipsum neque porttitor nulla, et sodales arcu ante fermentum tellus. Integer sagittis dolor sed augue fringilla accumsan. Cras vitae finibus arcu, sit amet varius dolor. Etiam id finibus dolor, vitae luctus velit. Proin efficitur augue nec pharetra accumsan. Aliquam lobortis nisl diam, vel fermentum purus finibus id. Etiam at finibus orci, et tincidunt turpis. Aliquam imperdiet congue lacus vel facilisis. Phasellus id magna vitae enim dapibus vestibulum vitae quis augue. Morbi eu consequat enim. Maecenas neque nulla, pulvinar sit amet consequat sed, tempor sed magna. Mauris lacinia sem feugiat faucibus aliquet. Etiam congue non turpis at commodo. Nulla facilisi.
+
+Nunc velit turpis, cursus ornare fringilla eu, lacinia posuere leo. Mauris rutrum ultricies dui et suscipit. Curabitur in euismod ligula. Curabitur vitae faucibus orci. Phasellus volutpat vestibulum diam sit amet vestibulum. In vel purus leo. Nulla condimentum lectus vestibulum lectus faucibus, id lobortis eros consequat. Proin mollis libero elit, vel aliquet nisi imperdiet et. Morbi ornare est velit, in vehicula nunc malesuada quis. Donec vehicula convallis interdum.
+
+Integer pellentesque in nibh vitae aliquet. Ut at justo id libero dignissim hendrerit. Interdum et malesuada fames ac ante ipsum primis in faucibus. Praesent quis ornare lectus. Nam malesuada non diam quis cursus. Phasellus a libero ligula. Suspendisse ligula elit, congue et nisi sit amet, cursus euismod dolor. Morbi aliquam, nulla a posuere pellentesque, diam massa ornare risus, nec eleifend neque eros et elit.
+
+Pellentesque a sodales dui. Sed in efficitur ante. Duis eget volutpat elit, et ornare est. Nam felis dolor, placerat mattis diam id, maximus lobortis quam. Sed pellentesque lobortis sem sed placerat. Pellentesque augue odio, molestie sed lectus sit amet, congue volutpat massa. Quisque congue consequat nunc id fringilla. Duis semper nulla eget enim venenatis dapibus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque varius turpis nibh, sit amet malesuada mauris malesuada quis. Vivamus dictum egestas placerat. Vivamus id augue elit.
+
+Cras fermentum volutpat eros, vitae euismod lorem viverra nec. Donec lectus augue, porta eleifend odio sit amet, condimentum rhoncus urna. Nunc sed odio velit. Morbi non cursus odio, eget imperdiet erat. Nunc rhoncus massa non neque volutpat, sit amet faucibus ante congue. Phasellus nec lorem vel leo accumsan lobortis. Maecenas id ligula bibendum purus suscipit posuere ac eget diam. Nam in quam pretium, semper erat auctor, iaculis odio. Maecenas placerat, nisi ac elementum tempor, felis nulla porttitor orci, ac rhoncus diam justo in elit. Etiam lobortis fermentum ligula in tincidunt. Donec quis vestibulum nunc. Sed eros diam, interdum in porta lobortis, gravida eu magna. Donec diam purus, finibus et sollicitudin quis, fringilla nec nisi. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur ultricies sagittis dapibus. Etiam ullamcorper aliquet libero, eu venenatis mauris suscipit id.
+
+Ut interdum eleifend sem, vel bibendum ipsum volutpat eget. Nunc ac dignissim augue. Aliquam ornare aliquet magna id dignissim. Vestibulum velit sem, lacinia eu rutrum in, rhoncus vitae mauris. Pellentesque scelerisque pulvinar mauris non cursus. Integer id dolor porta, bibendum sem vel, pretium tortor. Fusce a nisi convallis, interdum quam condimentum, suscipit dolor. Sed magna diam, efficitur non nunc in, tincidunt varius mi. Aliquam ullamcorper nulla eu fermentum bibendum. Vivamus a felis pretium, hendrerit enim vitae, hendrerit leo. Suspendisse lacinia lectus a diam consectetur suscipit. Aenean hendrerit nisl sed diam venenatis pellentesque. Nullam egestas lectus a consequat pharetra. Vivamus ornare tellus auctor, facilisis lacus id, feugiat dui. Nam id est ut est rhoncus varius.
+
+Aenean vel vehicula erat. Aenean gravida risus vitae purus sodales, quis dictum enim porta. Ut elit elit, fermentum sed posuere non, accumsan eu justo. Integer porta malesuada quam, et elementum massa suscipit nec. Donec in elit diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis suscipit vel ante volutpat vestibulum.
+
+Pellentesque ex arcu, euismod et sapien ut, vulputate suscipit enim. Donec mattis sagittis augue, et mattis lacus. Cras placerat consequat lorem sed luctus. Nam suscipit aliquam sem ac imperdiet. Mauris a semper augue, pulvinar fringilla magna. Integer pretium massa non risus commodo hendrerit. Sed dictum libero id erat sodales mattis. Etiam auctor dolor lectus, ut sagittis enim lobortis vitae. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Curabitur nec orci lobortis, cursus risus eget, sollicitudin massa. Integer vel tincidunt mi, id eleifend quam. Nullam facilisis nisl eu mauris congue, vitae euismod nisi malesuada. Vivamus sit amet urna et libero sagittis dictum.
+
+In hac habitasse platea dictumst. Aliquam erat volutpat. Ut dictum, mi a viverra venenatis, mi urna pulvinar nisi, nec gravida lectus diam eget urna. Ut dictum sit amet nisl ut dignissim. Sed sed mauris scelerisque, efficitur augue in, vulputate turpis. Proin dolor justo, bibendum et sollicitudin feugiat, imperdiet sed mi. Sed elementum vitae massa vel lobortis. Cras vitae massa sit amet libero dictum tempus.
+
+Vivamus ut mauris lectus. Curabitur placerat ornare scelerisque. Cras malesuada nunc quis tortor pretium bibendum vel sed dui. Cras lobortis nibh eu erat blandit, sit amet consequat neque fermentum. Phasellus imperdiet molestie tristique. Cras auctor purus erat, id mollis ligula porttitor eget. Mauris porta pharetra odio et finibus. Suspendisse eu est a ligula bibendum cursus. Mauris ac laoreet libero. Nullam volutpat sem quis rhoncus gravida.
+
+Donec malesuada lacus ac iaculis cursus. Sed sem orci, feugiat ac est ut, ultricies posuere nisi. Suspendisse potenti. Phasellus ut ultricies purus. Etiam sem tortor, fermentum quis aliquam eget, consequat ut nulla. Aliquam dictum metus in mi fringilla, vel gravida nulla accumsan. Cras aliquam eget leo vel posuere. Vivamus vitae malesuada nunc. Morbi placerat magna mi, id suscipit lacus auctor quis. Nam at lorem vel odio finibus fringilla ut ac velit. Donec laoreet at nibh quis vehicula.
+
+Fusce ac tristique nisi. Donec leo nisi, consectetur at tellus sit amet, consectetur ultrices dui. Quisque gravida mollis tempor. Maecenas semper, sapien ut dignissim feugiat, massa enim viverra dolor, non varius eros nulla nec felis. Nunc massa lacus, ornare et feugiat id, bibendum quis purus. Praesent viverra elit sit amet purus consectetur venenatis. Maecenas nibh risus, elementum sit amet enim sagittis, ultrices malesuada lectus. Vivamus non felis ante. Ut vulputate ex arcu. Aliquam porta gravida porta. Aliquam eros leo, malesuada quis eros non, maximus tristique neque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam ligula orci, mollis vel luctus nec, venenatis vitae est. Fusce rutrum convallis nisi.
+
+Nunc laoreet eget nibh in feugiat. Pellentesque nec arcu cursus, gravida dolor a, pellentesque nisi. Praesent vel justo blandit, placerat risus eget, consectetur orci. Sed maximus metus mi, ut euismod augue ultricies in. Nunc id risus hendrerit, aliquet lorem nec, congue justo. Vestibulum vel nunc ac est euismod mattis ac vitae nulla. Donec blandit luctus mauris, sit amet bibendum dui egestas et. Aenean nec lorem nec elit ornare rutrum nec eget ligula. Fusce a ipsum vitae neque elementum pharetra. Pellentesque ullamcorper ullamcorper libero, vitae porta sem sagittis vel. Interdum et malesuada fames ac ante ipsum primis in faucibus.
+
+Duis at massa sit amet risus pellentesque varius sit amet vitae eros. Cras tempor aliquet sapien, vehicula varius neque volutpat et. Donec purus nibh, pellentesque ut lobortis nec, ultricies ultricies nisl. Sed accumsan ut dui sit amet vulputate. Suspendisse eu facilisis massa, a hendrerit mauris. Nulla elementum molestie tincidunt. Donec mi justo, ornare vel tempor id, gravida et orci. Nam molestie erat nec nisi bibendum accumsan. Duis vitae tempor ante. Morbi congue mauris vel sagittis facilisis. Vivamus vehicula odio orci, a tempor nibh euismod in. Proin mattis, nibh at feugiat porta, purus velit posuere felis, quis volutpat sapien dui vel odio. Nam fermentum sem nec euismod aliquet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam erat volutpat.
+
+Mauris congue lacus tortor. Pellentesque arcu eros, accumsan imperdiet porttitor vitae, mattis nec justo. Nullam ac aliquam mauris. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse potenti. Fusce accumsan tempus felis a sagittis. Maecenas et velit odio. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aliquam eros lacus, volutpat non urna sed, tincidunt ullamcorper elit. Sed sit amet gravida libero. In varius mi vel diam sollicitudin mollis.
+
+Aenean varius, diam vitae hendrerit feugiat, libero augue ultrices odio, eget consequat sem tellus eu nisi. Nam dapibus enim et auctor sollicitudin. Nunc iaculis eros orci, ac accumsan eros malesuada ut. Ut semper augue felis, nec sodales lorem consectetur non. Cras gravida eleifend est, et sagittis eros imperdiet congue. Fusce id tellus dapibus nunc scelerisque tempus. Donec tempor placerat libero, in commodo nisi bibendum eu. Donec id eros non est sollicitudin luctus. Duis bibendum bibendum tellus nec viverra. Aliquam non faucibus ex, nec luctus dui. Curabitur efficitur varius urna non dignissim. Suspendisse elit elit, ultrices in elementum eu, tempor at magna.
+
+Nunc in purus sit amet mi laoreet pulvinar placerat eget sapien. Donec vel felis at dui ultricies euismod quis vel neque. Donec tincidunt urna non eros pretium blandit. Nullam congue tincidunt condimentum. Curabitur et libero nibh. Proin ultricies risus id imperdiet scelerisque. Suspendisse purus mi, viverra vitae risus ut, tempus tincidunt enim. Ut luctus lobortis nisl, eget venenatis tortor cursus non. Mauris finibus nisl quis gravida ultricies. Fusce elementum lacus sit amet nunc congue, in porta nulla tincidunt.
+
+Mauris ante risus, imperdiet blandit posuere in, blandit eu ipsum. Integer et auctor arcu. Integer quis elementum purus. Nunc in ultricies nisl, sed rutrum risus. Suspendisse venenatis eros nec lorem rhoncus, in scelerisque velit condimentum. Etiam condimentum quam felis, in elementum odio mattis et. In ut nibh porttitor, hendrerit tellus vel, luctus magna. Vestibulum et ligula et dolor pellentesque porta. Aenean efficitur porta massa et bibendum. Nulla vehicula sem in risus volutpat, a eleifend elit maximus.
+
+Proin orci lorem, auctor a felis eu, pretium lobortis nulla. Phasellus aliquam efficitur interdum. Sed sit amet velit rutrum est dictum facilisis. Duis cursus enim at nisl tincidunt, eu molestie elit vehicula. Cras pellentesque nisl id enim feugiat fringilla. In quis tincidunt neque. Nam eu consectetur dolor. Ut id interdum mauris. Mauris nunc tortor, placerat in tempor ut, vestibulum eu nisl. Integer vel dapibus ipsum. Nunc id erat pulvinar, tincidunt magna id, condimentum massa. Pellentesque consequat est eget odio placerat vehicula. Etiam augue neque, sagittis non leo eu, tristique scelerisque dui. Ut dui urna, blandit quis urna ac, tincidunt tristique turpis.
+
+Suspendisse venenatis rhoncus ligula ultrices condimentum. In id laoreet eros. Suspendisse suscipit fringilla leo id euismod. Sed in quam libero. Ut at ligula tellus. Sed tristique gravida dui, at egestas odio aliquam iaculis. Praesent imperdiet velit quis nibh consequat, quis pretium sem sagittis. Donec tortor ex, congue sit amet pulvinar ac, rutrum non est. Praesent ipsum magna, venenatis sit amet vulputate id, eleifend ac ipsum.
+
+In consequat, nisi iaculis laoreet elementum, massa mauris varius nisi, et porta nisi velit at urna. Maecenas sit amet aliquet eros, a rhoncus nisl. Maecenas convallis enim nunc. Morbi purus nisl, aliquam ac tincidunt sed, mattis in augue. Quisque et elementum quam, vitae maximus orci. Suspendisse hendrerit risus nec vehicula placerat. Nulla et lectus nunc. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+
+Etiam ut sodales ex. Nulla luctus, magna eu scelerisque sagittis, nibh quam consectetur neque, non rutrum dolor metus nec ex. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed egestas augue elit, sollicitudin accumsan massa lobortis ac. Curabitur placerat, dolor a aliquam maximus, velit ipsum laoreet ligula, id ullamcorper lacus nibh eget nisl. Donec eget lacus venenatis enim consequat auctor vel in.
+`;
+
+dotenv.config();
+
+/**
+ * Signs the provided data using a Hardware Security Module (HSM).
+ * This is a placeholder function that should be replaced with actual HSM SDK logic.
+ * @param {PrivateKey} key - Private key for signing
+ * @param {Uint8Array} bodyBytes - The data to be signed
+ * @returns {Promise<Uint8Array>} - The generated signature
+ */
+function hsmSign(key, bodyBytes) {
+    // This is a placeholder function that resembles the HSM signing process.
+    const signature = key.sign(bodyBytes);
+    return Promise.resolve(signature);
+}
+
+async function main() {
+    if (process.env.OPERATOR_ID == null || process.env.OPERATOR_KEY == null) {
+        throw new Error(
+            "Environment variables OPERATOR_ID, and OPERATOR_KEY are required.",
+        );
+    }
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    // eslint-disable-next-line deprecation/deprecation
+    const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+    const networkName = process.env.HEDERA_NETWORK;
+
+    const client = Client.forName(networkName).setOperator(
+        operatorId,
+        operatorKey,
+    );
+
+    try {
+        /**
+         * Step 1: Create accounts for the transfer
+         */
+        const senderPrivateKey = PrivateKey.generateECDSA();
+        const receiverPrivateKey = PrivateKey.generateECDSA();
+
+        const senderId = (
+            await (
+                await new AccountCreateTransaction()
+                    .setECDSAKeyWithAlias(senderPrivateKey)
+                    .setInitialBalance(new Hbar(10))
+                    .freezeWith(client)
+                    .execute(client)
+            ).getReceipt(client)
+        ).accountId;
+
+        const receiverId = (
+            await (
+                await new AccountCreateTransaction()
+                    .setECDSAKeyWithAlias(receiverPrivateKey)
+                    .setInitialBalance(new Hbar(1))
+                    .freezeWith(client)
+                    .execute(client)
+            ).getReceipt(client)
+        ).accountId;
+
+        /**
+         * Example 1: Single Node Transaction
+         *
+         * This example demonstrates how to sign a transaction body bytes
+         * using an HSM for a single node transaction.
+         */
+        console.log("---Example 1: Single Node Transaction---");
+
+        const nodeAccountId = /** @type {AccountId} */ (
+            Object.values(client.network)[0]
+        );
+
+        const singleNodeTx = new TransferTransaction()
+            .addHbarTransfer(senderId, Hbar.fromTinybars(-100))
+            .addHbarTransfer(receiverId, Hbar.fromTinybars(100))
+            .setNodeAccountIds([nodeAccountId])
+            .setTransactionId(TransactionId.generate(senderId))
+            .freezeWith(client);
+
+        // Get the transaction body bytes for signing
+        const singleNodeSignableBodyBytesList =
+            singleNodeTx.signableNodeBodyBytesList;
+        const singleNodeSignatureMap = new SignatureMap();
+
+        // Sign the transaction body bytes using HSM
+        for (const {
+            nodeAccountId,
+            transactionId,
+            signableTransactionBodyBytes,
+        } of singleNodeSignableBodyBytesList) {
+            const signature = await hsmSign(
+                senderPrivateKey,
+                signableTransactionBodyBytes,
+            );
+
+            singleNodeSignatureMap.addSignature(
+                nodeAccountId,
+                transactionId,
+                senderPrivateKey.publicKey,
+                signature,
+            );
+        }
+
+        // Add the signatures to the transaction
+        singleNodeTx.addSignature(
+            senderPrivateKey.publicKey,
+            singleNodeSignatureMap,
+        );
+
+        // Execute the transaction
+        const singleNodeResponse = await singleNodeTx.execute(client);
+        const singleNodeReceipt = await singleNodeResponse.getReceipt(client);
+
+        console.log(
+            "Single node transaction status:",
+            singleNodeReceipt.status.toString(),
+        );
+
+        /**
+         * Example 2: Multi-Node Batched Transaction
+         * Note: This is example makes sense only in a multi-node environment (testnet, mainnet, etc).
+         *
+         * This example demonstrates how to sign transaction body bytes
+         * using an HSM for a multi-node batched transaction.
+         */
+        console.log("\n---Example 2: Multi-Node Batched Transaction---");
+
+        const fileId = (
+            await (
+                await (
+                    await new FileCreateTransaction()
+                        .setKeys([senderPrivateKey.publicKey])
+                        .setContents("[e2e::FileCreateTransaction]")
+                        .setMaxTransactionFee(new Hbar(5))
+                        .freezeWith(client)
+                        .sign(senderPrivateKey)
+                ).execute(client)
+            ).getReceipt(client)
+        ).fileId;
+
+        console.log(`Created file with ID: ${fileId.toString()}`);
+
+        const allAvailableNodeAccountIds = Object.values(client.network);
+
+        const nodeAccountIds = [
+            /** @type {AccountId} */ (allAvailableNodeAccountIds[0]),
+            /** @type {AccountId} */ (allAvailableNodeAccountIds[1]),
+            /** @type {AccountId} */ (allAvailableNodeAccountIds[2]),
+        ];
+
+        const multiNodeTx = new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(bigContents)
+            .setNodeAccountIds(nodeAccountIds)
+            .setMaxTransactionFee(new Hbar(5))
+            .setTransactionId(TransactionId.generate(senderId))
+            .freezeWith(client);
+
+        console.log(
+            `Signing transaction with HSM for nodes: ${nodeAccountIds
+                .map((id) => id.toString())
+                .join(", ")}`,
+        );
+
+        // Get the transaction body bytes for each node
+        const multiNodeSignableBodyBytesList =
+            multiNodeTx.signableNodeBodyBytesList;
+        const multiNodeSignatureMap = new SignatureMap();
+
+        // Sign the transaction body bytes for each node using HSM
+        for (const {
+            nodeAccountId,
+            transactionId,
+            signableTransactionBodyBytes,
+        } of multiNodeSignableBodyBytesList) {
+            const nodeSignature = await hsmSign(
+                senderPrivateKey,
+                signableTransactionBodyBytes,
+            );
+
+            multiNodeSignatureMap.addSignature(
+                nodeAccountId,
+                transactionId,
+                senderPrivateKey.publicKey,
+                nodeSignature,
+            );
+        }
+
+        // Add the signatures to the transaction
+        multiNodeTx.addSignature(
+            senderPrivateKey.publicKey,
+            multiNodeSignatureMap,
+        );
+
+        // Execute the transaction
+        const multiNodeResponse = await multiNodeTx.execute(client);
+        const multiNodeReceipt = await multiNodeResponse.getReceipt(client);
+        console.log(
+            "Multi-node file append transaction status:",
+            multiNodeReceipt.status.toString(),
+        );
+
+        // Verify the contents were appended
+        const contents = await new FileContentsQuery()
+            .setFileId(fileId)
+            .execute(client);
+
+        console.log(
+            `File content length according to \`FileContentsQuery\`: ${contents.length}`,
+        );
+    } catch (error) {
+        console.error(error);
+    }
+
+    client.close();
+}
+
+void main();

--- a/src/transaction/SignableNodeTransactionBodyBytes.js
+++ b/src/transaction/SignableNodeTransactionBodyBytes.js
@@ -4,7 +4,10 @@
  */
 
 /**
- * Represents a transaction body that is ready for signing, associated with a specific node account.
+ * Represents a transaction body that is ready for signing, associated with a specific node account and transaction identifier.
+ * @property {AccountId} nodeAccountId - The account ID of the node.
+ * @property {TransactionId} transactionId - The transactionId of the transaction, (when dealing with a chunked transaction, this is the transactionId of the chunk).
+ * @property {Uint8Array} signableTransactionBodyBytes - The transaction body bytes ready for signing.
  */
 export default class SignableNodeTransactionBodyBytes {
     /**
@@ -22,7 +25,8 @@ export default class SignableNodeTransactionBodyBytes {
         this.nodeAccountId = nodeAccountId;
 
         /**
-         * The node account identifier associated with the transaction.
+         * The transactionId identifier.
+         * Note: When dealing with a chunked transaction, this is the transactionId of the chunk.
          * @type {TransactionId}
          */
         this.transactionId = transactionId;

--- a/src/transaction/SignableNodeTransactionBodyBytes.js
+++ b/src/transaction/SignableNodeTransactionBodyBytes.js
@@ -1,0 +1,36 @@
+/**
+ * @typedef {import("../account/AccountId").default} AccountId
+ * @typedef {import("../transaction/TransactionId").default} TransactionId
+ */
+
+/**
+ * Represents a transaction body that is ready for signing, associated with a specific node account.
+ */
+export default class SignableNodeTransactionBodyBytes {
+    /**
+     * Creates a new instance of NodeSignableTransaction.
+     *
+     * @param {AccountId} nodeAccountId - The account ID of the node.
+     * @param {TransactionId} transactionId - The transactionId of the transaction.
+     * @param {Uint8Array} signableTransactionBodyBytes - The transaction body bytes ready for signing.
+     */
+    constructor(nodeAccountId, transactionId, signableTransactionBodyBytes) {
+        /**
+         * The node account identifier associated with the transaction.
+         * @type {AccountId}
+         */
+        this.nodeAccountId = nodeAccountId;
+
+        /**
+         * The node account identifier associated with the transaction.
+         * @type {TransactionId}
+         */
+        this.transactionId = transactionId;
+
+        /**
+         * The bytes of the transaction body, ready to be signed.
+         * @type {Uint8Array}
+         */
+        this.signableTransactionBodyBytes = signableTransactionBodyBytes;
+    }
+}

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1311,7 +1311,7 @@ export default class Transaction extends Executable {
     }
 
     /**
-     * Returns a Map of nodeId => bodyBytes for each node the transaction is intended for.
+     * Returns a List of SignableNodeTransactionBodyBytes for each node the transaction is intended for.
      * These are the canonical bytes that must be signed externally (e.g., via HSM).
      *
      * @returns {SignableNodeTransactionBodyBytes[]}

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -20,6 +20,7 @@ import Timestamp from "../Timestamp.js";
 import * as util from "../util.js";
 import CustomFeeLimit from "./CustomFeeLimit.js";
 import Key from "../Key.js";
+import SignableNodeTransactionBodyBytes from "./SignableNodeTransactionBodyBytes.js";
 
 /**
  * @typedef {import("bignumber.js").default} BigNumber
@@ -1307,6 +1308,45 @@ export default class Transaction extends Executable {
      */
     get batchKey() {
         return this._batchKey;
+    }
+
+    /**
+     * Returns a Map of nodeId => bodyBytes for each node the transaction is intended for.
+     * These are the canonical bytes that must be signed externally (e.g., via HSM).
+     *
+     * @returns {SignableNodeTransactionBodyBytes[]}
+     */
+    get signableNodeBodyBytesList() {
+        this._requireFrozen();
+
+        return this._signedTransactions.list.map((signedTransaction) => {
+            if (!signedTransaction.bodyBytes) {
+                throw new Error("Missing bodyBytes in signed transaction.");
+            }
+
+            const body = HieroProto.proto.TransactionBody.decode(
+                signedTransaction.bodyBytes,
+            );
+
+            if (!body.nodeAccountID) {
+                throw new Error("Missing nodeAccountID in transaction body.");
+            }
+
+            const nodeAccountId = AccountId._fromProtobuf(body.nodeAccountID);
+            if (!body.transactionID) {
+                throw new Error("Missing transactionID in transaction body.");
+            }
+
+            const transactionId = TransactionId._fromProtobuf(
+                body.transactionID,
+            );
+
+            return new SignableNodeTransactionBodyBytes(
+                nodeAccountId,
+                transactionId,
+                signedTransaction.bodyBytes,
+            );
+        });
     }
 
     /**

--- a/test/integration/TransactionIntegrationTest.js
+++ b/test/integration/TransactionIntegrationTest.js
@@ -13,9 +13,13 @@ import {
     KeyList,
     Status,
     AccountCreateTransaction,
+    FileAppendTransaction,
+    FileContentsQuery,
 } from "../../src/exports.js";
 import * as hex from "../../src/encoding/hex.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+import SignableNodeTransactionBodyBytes from "../../src/transaction/SignableNodeTransactionBodyBytes.js";
+import * as HieroProto from "@hashgraph/proto";
 
 import { Client } from "./client/NodeIntegrationTestEnv.js";
 import {
@@ -1045,6 +1049,207 @@ describe("TransactionIntegration", function () {
             expect(signTransferTxReceipt.status.toString()).to.be.equal(
                 "SUCCESS",
             );
+        });
+    });
+
+    describe("HSM signing of signable transaction body bytes integration tests", function () {
+        let env, client, senderId, senderKey, receiverId;
+
+        const bigContents = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur aliquam augue sem, ut mattis dui laoreet a. Curabitur consequat est euismod, scelerisque metus et, tristique dui. Nulla commodo mauris ut faucibus ultricies. Quisque venenatis nisl nec augue tempus, at efficitur elit eleifend. Duis pharetra felis metus, sed dapibus urna vehicula id. Duis non venenatis turpis, sit amet ornare orci. Donec non interdum quam. Sed finibus nunc et risus finibus, non sagittis lorem cursus. Proin pellentesque tempor aliquam. Sed congue nisl in enim bibendum, condimentum vehicula nisi feugiat.
+
+Suspendisse non sodales arcu. Suspendisse sodales, lorem ac mollis blandit, ipsum neque porttitor nulla, et sodales arcu ante fermentum tellus. Integer sagittis dolor sed augue fringilla accumsan. Cras vitae finibus arcu, sit amet varius dolor. Etiam id finibus dolor, vitae luctus velit. Proin efficitur augue nec pharetra accumsan. Aliquam lobortis nisl diam, vel fermentum purus finibus id. Etiam at finibus orci, et tincidunt turpis. Aliquam imperdiet congue lacus vel facilisis. Phasellus id magna vitae enim dapibus vestibulum vitae quis augue. Morbi eu consequat enim. Maecenas neque nulla, pulvinar sit amet consequat sed, tempor sed magna. Mauris lacinia sem feugiat faucibus aliquet. Etiam congue non turpis at commodo. Nulla facilisi.
+`;
+
+        /**
+         * Signs the provided data using a Hardware Security Module (HSM).
+         * This is a placeholder function that should be replaced with actual HSM SDK logic.
+         * @param {PrivateKey} key - Private key for signing
+         * @param {Uint8Array} bodyBytes - The data to be signed
+         * @returns {Promise<Uint8Array>} - The generated signature
+         */
+        function hsmSign(key, bodyBytes) {
+            // This is a placeholder function that resembles the HSM signing process.
+            const signature = key.sign(bodyBytes);
+            return Promise.resolve(signature);
+        }
+
+        beforeAll(async function () {
+            env = await IntegrationTestEnv.new();
+            client = env.client;
+
+            // Create test accounts
+            senderKey = PrivateKey.generateECDSA();
+            const receiverKey = PrivateKey.generateECDSA();
+
+            senderId = (
+                await (
+                    await new AccountCreateTransaction()
+                        .setECDSAKeyWithAlias(senderKey)
+                        .setInitialBalance(new Hbar(10))
+                        .freezeWith(client)
+                        .execute(client)
+                ).getReceipt(client)
+            ).accountId;
+
+            receiverId = (
+                await (
+                    await new AccountCreateTransaction()
+                        .setECDSAKeyWithAlias(receiverKey)
+                        .setInitialBalance(new Hbar(1))
+                        .freezeWith(client)
+                        .execute(client)
+                ).getReceipt(client)
+            ).accountId;
+        });
+
+        afterAll(async function () {
+            await env.close();
+        });
+
+        it("should accept external HSM signature for the transaction body bytes for a single-node transfer transaction", async function () {
+            // Get a single node account ID from the network
+            const nodeAccountId = Object.values(client.network)[0];
+
+            // Create and freeze a transfer transaction
+            const transferTx = new TransferTransaction()
+                .addHbarTransfer(senderId, new Hbar(-1))
+                .addHbarTransfer(receiverId, new Hbar(1))
+                .setNodeAccountIds([nodeAccountId])
+                .setTransactionId(TransactionId.generate(senderId))
+                .freezeWith(client);
+
+            // Get the signable node body bytes
+            const signableBytesList = transferTx.signableNodeBodyBytesList;
+
+            // Verify we have exactly one signable bytes object
+            expect(signableBytesList).to.be.an("array");
+            expect(signableBytesList.length).to.equal(1);
+
+            // Verify the signable bytes object
+            const signableBytes = signableBytesList[0];
+            expect(signableBytes).to.be.instanceOf(
+                SignableNodeTransactionBodyBytes,
+            );
+            expect(signableBytes.nodeAccountId.toString()).to.equal(
+                nodeAccountId.toString(),
+            );
+            expect(signableBytes.transactionId.accountId.toString()).to.equal(
+                senderId.toString(),
+            );
+            expect(signableBytes.signableTransactionBodyBytes).to.be.instanceOf(
+                Uint8Array,
+            );
+
+            // Verify the transaction body can be decoded and contains transfer data
+            const body = HieroProto.proto.TransactionBody.decode(
+                signableBytes.signableTransactionBodyBytes,
+            );
+
+            expect(body).to.have.property("cryptoTransfer");
+
+            // Sign the transaction body bytes using HSM
+            const signature = await hsmSign(
+                senderKey,
+                signableBytes.signableTransactionBodyBytes,
+            );
+
+            // Verify the signature was generated
+            expect(signature).to.be.instanceOf(Uint8Array);
+            expect(signature.length).to.be.greaterThan(0);
+
+            // Add the signature to the transaction
+            transferTx.addSignature(senderKey.publicKey, signature);
+
+            // Execute the transaction
+            const response = await transferTx.execute(client);
+            const receipt = await response.getReceipt(client);
+
+            // Verify the transaction was successful
+            expect(receipt.status.toString()).to.equal("SUCCESS");
+        });
+
+        it("should accept external HSM signature for the transaction body bytes for a single-node file append chunked transaction", async function () {
+            // Get a single node account ID from the network
+            const nodeAccountId = Object.values(client.network)[0];
+
+            // Create a file first
+            const fileId = (
+                await (
+                    await (
+                        await new FileCreateTransaction()
+                            .setKeys([senderKey.publicKey])
+                            .setContents("[e2e::FileCreateTransaction]")
+                            .setMaxTransactionFee(new Hbar(5))
+                            .freezeWith(client)
+                            .sign(senderKey)
+                    ).execute(client)
+                ).getReceipt(client)
+            ).fileId;
+
+            // Create and freeze a file append transaction
+            const fileAppendTx = new FileAppendTransaction()
+                .setFileId(fileId)
+                .setContents(bigContents)
+                .setNodeAccountIds([nodeAccountId])
+                .setMaxTransactionFee(new Hbar(5))
+                .setTransactionId(TransactionId.generate(senderId))
+                .freezeWith(client);
+
+            // Get the signable node body bytes
+            const signableBytesList = fileAppendTx.signableNodeBodyBytesList;
+
+            // Verify we have exactly one signable bytes object
+            expect(signableBytesList).to.be.an("array");
+            expect(signableBytesList.length).to.equal(1);
+
+            // Verify the signable bytes object
+            const signableBytes = signableBytesList[0];
+            expect(signableBytes).to.be.instanceOf(
+                SignableNodeTransactionBodyBytes,
+            );
+            expect(signableBytes.nodeAccountId.toString()).to.equal(
+                nodeAccountId.toString(),
+            );
+            expect(signableBytes.transactionId.accountId.toString()).to.equal(
+                senderId.toString(),
+            );
+            expect(signableBytes.signableTransactionBodyBytes).to.be.instanceOf(
+                Uint8Array,
+            );
+
+            // Verify the transaction body can be decoded and contains file append data
+            const body = HieroProto.proto.TransactionBody.decode(
+                signableBytes.signableTransactionBodyBytes,
+            );
+            expect(body).to.have.property("fileAppend");
+
+            // Sign the transaction body bytes using HSM
+            const signature = await hsmSign(
+                senderKey,
+                signableBytes.signableTransactionBodyBytes,
+            );
+
+            // Verify the signature was generated
+            expect(signature).to.be.instanceOf(Uint8Array);
+            expect(signature.length).to.be.greaterThan(0);
+
+            // Add the signature to the transaction
+            fileAppendTx.addSignature(senderKey.publicKey, signature);
+
+            // Execute the transaction
+            const response = await fileAppendTx.execute(client);
+            const receipt = await response.getReceipt(client);
+
+            // Verify the transaction was successful
+            expect(receipt.status.toString()).to.equal("SUCCESS");
+
+            // Verify the contents were appended
+            const contents = await new FileContentsQuery()
+                .setFileId(fileId)
+                .execute(client);
+
+            expect(contents.length).to.be.greaterThan(0);
         });
     });
 });

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -11,7 +11,6 @@ import {
     Transaction,
     TransactionId,
     TransferTransaction,
-    FileAppendTransaction,
 } from "../../src/index.js";
 import * as hex from "../../src/encoding/hex.js";
 import Client from "../../src/client/NodeClient.js";


### PR DESCRIPTION
### Description
This PR introduces support for external transaction signing using Hardware Security Modules (HSMs) in the JavaScript SDK. It provides a new API surface to expose canonical `bodyBytes` that are valid for signing, allowing signatures to be generated securely outside the SDK and injected back into the transaction. This feature is essential for enterprise and regulated environments where private keys must remain within secure hardware.

### Added
- Support for external transaction signing via HSM: Introduced `SignableNodeTransactionBodyBytes` and `signableNodeBodyBytesList` to enable enterprise users to extract canonical `bodyBytes`, sign externally (e.g., with an HSM or KMS), and inject signatures back into transactions securely. This improves SDK usability for high-security environments.

  - New class `SignableNodeTransactionBodyBytes` encapsulates the `nodeAccountId`, `transactionId`, and canonical `bodyBytes`.
  - New API `Transaction.signableNodeBodyBytesList` returns node-specific, signable transaction bytes for HSM workflows.

### Documentation
- Added usage examples and test cases for HSM-based signing with `signableNodeBodyBytesList` in the JavaScript SDK docs

**Related issue(s)**:

Fixes #3044

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
