### PR TITLE
feat: add shard and realm pesistence to the client

### DIFF
--- a/examples/get-address-book.js
+++ b/examples/get-address-book.js
@@ -20,7 +20,7 @@ async function main() {
     }
 
     const addressBook = await new AddressBookQuery()
-        .setFileId(FileId.ADDRESS_BOOK)
+        .setFileId(FileId.getAddressBookFileIdFor(0, 0))
         .execute(client);
 
     console.log(JSON.stringify(addressBook.toJSON(), null, 2));

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -802,7 +802,7 @@ export default class Client {
      *
      * @param {{[key: string]: (string | AccountId)}} network
      */
-    static validateNetworkConsistency(network) {
+    static _validateNetworkConsistency(network) {
         let shard = undefined;
         let realm = undefined;
 
@@ -815,7 +815,7 @@ export default class Client {
                 realm = nodeRealm;
             } else if (shard !== nodeShard || realm !== nodeRealm) {
                 throw new Error(
-                    `All nodes must be within the same shard and realm. Found nodes in shard ${String(shard)}.${String(realm)} and ${String(nodeShard)}.${String(nodeRealm)}`,
+                    "Network is not valid, all nodes must be in the same shard and realm",
                 );
             }
         }
@@ -829,7 +829,7 @@ export default class Client {
      * @param {{[key: string]: (string | AccountId)}} network
      * @returns {{shard: number, realm: number}}
      */
-    static extractShardRealm(network) {
+    static _extractShardRealm(network) {
         const entries = Object.entries(network);
         if (entries.length === 0) {
             return { shard: 0, realm: 0 };

--- a/src/client/NativeClient.js
+++ b/src/client/NativeClient.js
@@ -75,9 +75,9 @@ export default class NativeClient extends Client {
                         );
                 }
             } else if (props.network != null) {
-                Client.validateNetworkConsistency(props.network);
+                Client._validateNetworkConsistency(props.network);
 
-                const { shard, realm } = Client.extractShardRealm(
+                const { shard, realm } = Client._extractShardRealm(
                     props.network,
                 );
 

--- a/src/client/NativeClient.js
+++ b/src/client/NativeClient.js
@@ -75,6 +75,17 @@ export default class NativeClient extends Client {
                         );
                 }
             } else if (props.network != null) {
+                Client.validateNetworkConsistency(props.network);
+
+                const { shard, realm } = Client.extractShardRealm(
+                    props.network,
+                );
+
+                // Shard and realm are inferred from the network, so we need to set them here
+                // to ensure that the client is properly configured.
+                this._shard = shard;
+                this._realm = realm;
+
                 this.setNetwork(props.network);
             }
         }
@@ -108,7 +119,10 @@ export default class NativeClient extends Client {
      * @returns {NativeClient}
      */
     static forNetwork(network) {
-        return new NativeClient({ network, scheduleNetworkUpdate: false });
+        return new NativeClient({
+            network,
+            scheduleNetworkUpdate: false,
+        });
     }
 
     /**

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -194,11 +194,13 @@ export default class NodeClient extends Client {
      * @returns {Promise<NodeClient>}
      */
     static async forMirrorNetwork(mirrorNetwork, shard, realm) {
+        const INITIAL_UPDATE_PERIOD = 10_000;
+
         const client = new NodeClient({
             mirrorNetwork,
             shard,
             realm,
-        }).setNetworkUpdatePeriod(10_000);
+        }).setNetworkUpdatePeriod(INITIAL_UPDATE_PERIOD);
 
         await client.updateNetwork();
 

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -74,9 +74,9 @@ export default class NodeClient extends Client {
             if (typeof props.network === "string") {
                 this._setNetworkFromName(props.network);
             } else if (props.network != null) {
-                Client.validateNetworkConsistency(props.network);
+                Client._validateNetworkConsistency(props.network);
 
-                const { shard, realm } = Client.extractShardRealm(
+                const { shard, realm } = Client._extractShardRealm(
                     props.network,
                 );
 

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -12,8 +12,6 @@ import * as mainnet from "./addressbooks/mainnet.js";
 import * as testnet from "./addressbooks/testnet.js";
 import * as previewnet from "./addressbooks/previewnet.js";
 import * as hex from "../encoding/hex.js";
-import AddressBookQuery from "../network/AddressBookQuery.js";
-import FileId from "../file/FileId.js";
 
 const readFileAsync = util.promisify(fs.readFile);
 
@@ -76,6 +74,17 @@ export default class NodeClient extends Client {
             if (typeof props.network === "string") {
                 this._setNetworkFromName(props.network);
             } else if (props.network != null) {
+                Client.validateNetworkConsistency(props.network);
+
+                const { shard, realm } = Client.extractShardRealm(
+                    props.network,
+                );
+
+                // Shard and realm are inferred from the network, so we need to set them here
+                // to ensure that the client is properly configured.
+                this._shard = shard;
+                this._realm = realm;
+
                 this.setNetwork(props.network);
             }
 
@@ -140,7 +149,10 @@ export default class NodeClient extends Client {
      * @returns {NodeClient}
      */
     static forNetwork(network, props) {
-        return new NodeClient({ network, ...props });
+        return new NodeClient({
+            network,
+            ...props,
+        });
     }
 
     /**
@@ -177,19 +189,18 @@ export default class NodeClient extends Client {
 
     /**
      * @param {string[] | string} mirrorNetwork
+     * @param {number} [shard]
+     * @param {number} [realm]
      * @returns {Promise<NodeClient>}
      */
-    static async forMirrorNetwork(mirrorNetwork) {
-        const client = new NodeClient();
+    static async forMirrorNetwork(mirrorNetwork, shard, realm) {
+        const client = new NodeClient({
+            mirrorNetwork,
+            shard,
+            realm,
+        }).setNetworkUpdatePeriod(10_000);
 
-        client.setMirrorNetwork(mirrorNetwork).setNetworkUpdatePeriod(10000);
-
-        // Execute an address book query to get the network nodes
-        const addressBook = await new AddressBookQuery()
-            .setFileId(FileId.ADDRESS_BOOK)
-            .execute(client);
-
-        client.setNetworkFromAddressBook(addressBook);
+        await client.updateNetwork();
 
         return client;
     }
@@ -213,7 +224,10 @@ export default class NodeClient extends Client {
      * @returns {NodeClient}
      */
     static forLocalNode(props = { scheduleNetworkUpdate: false }) {
-        return new NodeClient({ network: "local-node", ...props });
+        return new NodeClient({
+            network: "local-node",
+            ...props,
+        });
     }
 
     /**

--- a/src/client/WebClient.js
+++ b/src/client/WebClient.js
@@ -79,9 +79,9 @@ export default class WebClient extends Client {
                         );
                 }
             } else if (props.network != null) {
-                Client.validateNetworkConsistency(props.network);
+                Client._validateNetworkConsistency(props.network);
 
-                const { shard, realm } = Client.extractShardRealm(
+                const { shard, realm } = Client._extractShardRealm(
                     props.network,
                 );
 

--- a/src/client/WebClient.js
+++ b/src/client/WebClient.js
@@ -2,8 +2,6 @@
 
 import Client from "./Client.js";
 import WebChannel from "../channel/WebChannel.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import AccountId from "../account/AccountId.js";
 import LedgerId from "../LedgerId.js";
 import {
     MAINNET,
@@ -13,6 +11,7 @@ import {
 
 /**
  * @typedef {import("./Client.js").ClientConfiguration} ClientConfiguration
+ * @typedef {import("../account/AccountId.js").default} AccountId
  */
 
 export const Network = {
@@ -80,6 +79,17 @@ export default class WebClient extends Client {
                         );
                 }
             } else if (props.network != null) {
+                Client.validateNetworkConsistency(props.network);
+
+                const { shard, realm } = Client.extractShardRealm(
+                    props.network,
+                );
+
+                // Shard and realm are inferred from the network, so we need to set them here
+                // to ensure that the client is properly configured.
+                this._shard = shard;
+                this._realm = realm;
+
                 this.setNetwork(props.network);
             }
         }
@@ -113,7 +123,10 @@ export default class WebClient extends Client {
      * @returns {WebClient}
      */
     static forNetwork(network) {
-        return new WebClient({ network, scheduleNetworkUpdate: false });
+        return new WebClient({
+            network,
+            scheduleNetworkUpdate: false,
+        });
     }
 
     /**
@@ -121,7 +134,10 @@ export default class WebClient extends Client {
      * @returns {WebClient}
      */
     static forName(network) {
-        return new WebClient({ network, scheduleNetworkUpdate: false });
+        return new WebClient({
+            network,
+            scheduleNetworkUpdate: false,
+        });
     }
 
     /**

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -31,6 +31,33 @@ export default class FileId {
     }
 
     /**
+     * @param {number} shard
+     * @param {number} realm
+     * @returns {FileId}
+     */
+    static getAddressBookFileIdFor(shard = 0, realm = 0) {
+        return new FileId({ num: 102, shard, realm });
+    }
+
+    /**
+     * @param {number} shard
+     * @param {number} realm
+     * @returns {FileId}
+     */
+    static getFeeScheduleFileIdFor(shard = 0, realm = 0) {
+        return new FileId({ num: 111, shard, realm });
+    }
+
+    /**
+     * @param {number} shard
+     * @param {number} realm
+     * @returns {FileId}
+     */
+    static getExchangeRatesFileIdFor(shard = 0, realm = 0) {
+        return new FileId({ num: 112, shard, realm });
+    }
+
+    /**
      * @param {string} text
      * @returns {FileId}
      */
@@ -163,18 +190,3 @@ export default class FileId {
         );
     }
 }
-
-/**
- * The public node address book for the current network.
- */
-FileId.ADDRESS_BOOK = new FileId(102);
-
-/**
- * The current fee schedule for the network.
- */
-FileId.FEE_SCHEDULE = new FileId(111);
-
-/**
- * The current exchange rate of HBAR to USD.
- */
-FileId.EXCHANGE_RATES = new FileId(112);

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -190,3 +190,18 @@ export default class FileId {
         );
     }
 }
+
+/**
+ * The public node address book for the current network.
+ */
+FileId.ADDRESS_BOOK = new FileId(102);
+
+/**
+ * The current fee schedule for the network.
+ */
+FileId.FEE_SCHEDULE = new FileId(111);
+
+/**
+ * The current exchange rate of HBAR to USD.
+ */
+FileId.EXCHANGE_RATES = new FileId(112);

--- a/test/unit/FileId.js
+++ b/test/unit/FileId.js
@@ -1,0 +1,53 @@
+import FileId from "../../src/file/FileId.js";
+
+describe("FileId", function () {
+    describe("static factory methods", function () {
+        describe("getAddressBookFileIdFor", function () {
+            it("should create FileId with default shard and realm", function () {
+                const fileId = FileId.getAddressBookFileIdFor();
+                expect(fileId.shard.toNumber()).to.equal(0);
+                expect(fileId.realm.toNumber()).to.equal(0);
+                expect(fileId.num.toNumber()).to.equal(102);
+            });
+
+            it("should create FileId with custom shard and realm", function () {
+                const fileId = FileId.getAddressBookFileIdFor(1, 2);
+                expect(fileId.shard.toNumber()).to.equal(1);
+                expect(fileId.realm.toNumber()).to.equal(2);
+                expect(fileId.num.toNumber()).to.equal(102);
+            });
+        });
+
+        describe("getFeeScheduleFileIdFor", function () {
+            it("should create FileId with default shard and realm", function () {
+                const fileId = FileId.getFeeScheduleFileIdFor();
+                expect(fileId.shard.toNumber()).to.equal(0);
+                expect(fileId.realm.toNumber()).to.equal(0);
+                expect(fileId.num.toNumber()).to.equal(111);
+            });
+
+            it("should create FileId with custom shard and realm", function () {
+                const fileId = FileId.getFeeScheduleFileIdFor(1, 2);
+                expect(fileId.shard.toNumber()).to.equal(1);
+                expect(fileId.realm.toNumber()).to.equal(2);
+                expect(fileId.num.toNumber()).to.equal(111);
+            });
+        });
+
+        describe("getExchangeRatesFileIdFor", function () {
+            it("should create FileId with default shard and realm", function () {
+                const fileId = FileId.getExchangeRatesFileIdFor();
+                expect(fileId.shard.toNumber()).to.equal(0);
+                expect(fileId.realm.toNumber()).to.equal(0);
+                expect(fileId.num.toNumber()).to.equal(112);
+            });
+
+            it("should create FileId with custom shard and realm", function () {
+                const fileId = FileId.getExchangeRatesFileIdFor(1, 2);
+                expect(fileId.shard.toNumber()).to.equal(1);
+                expect(fileId.realm.toNumber()).to.equal(2);
+                expect(fileId.num.toNumber()).to.equal(112);
+            });
+        });
+    });
+});

--- a/test/unit/node/NodeClient.js
+++ b/test/unit/node/NodeClient.js
@@ -292,7 +292,9 @@ describe("Client", function () {
                     NodeClient.forNetwork(nodes, {
                         scheduleNetworkUpdate: false,
                     }),
-                ).to.throw("All nodes must be within the same shard and realm");
+                ).to.throw(
+                    "Network is not valid, all nodes must be in the same shard and realm",
+                );
             });
 
             it("should throw error when nodes are in different realms", function () {
@@ -305,7 +307,9 @@ describe("Client", function () {
                     NodeClient.forNetwork(nodes, {
                         scheduleNetworkUpdate: false,
                     }),
-                ).to.throw("All nodes must be within the same shard and realm");
+                ).to.throw(
+                    "Network is not valid, all nodes must be in the same shard and realm",
+                );
             });
 
             it("should use network node shard and realm values over explicitly provided values", function () {

--- a/test/unit/node/NodeClient.js
+++ b/test/unit/node/NodeClient.js
@@ -237,4 +237,94 @@ describe("Client", function () {
             await client.close();
         });
     });
+
+    describe("shard and realm configuration", function () {
+        it("should set default shard and realm to 0", function () {
+            const client = new NodeClient({ scheduleNetworkUpdate: false });
+            expect(client._shard).to.equal(0);
+            expect(client._realm).to.equal(0);
+        });
+
+        it("should set custom shard and realm values", function () {
+            const client = new NodeClient({
+                shard: 1,
+                realm: 2,
+                scheduleNetworkUpdate: false,
+            });
+            expect(client._shard).to.equal(1);
+            expect(client._realm).to.equal(2);
+        });
+    });
+
+    describe("factory methods shard and realm behavior", function () {
+        describe("forNetwork", function () {
+            it("should set custom shard and realm values", function () {
+                const client = NodeClient.forNetwork(
+                    { "0.testnet.hedera.com:50211": "0.0.3" },
+                    { scheduleNetworkUpdate: false },
+                );
+                expect(client._shard).to.equal(0);
+                expect(client._realm).to.equal(0);
+            });
+
+            it("should create client with nodes in same shard and realm", function () {
+                const nodes = {
+                    "0.testnet.hedera.com:50211": new AccountId(1, 2, 3),
+                    "34.94.106.61:50211": new AccountId(1, 2, 3),
+                    "50.18.132.211:50211": new AccountId(1, 2, 3),
+                };
+
+                const client = NodeClient.forNetwork(nodes, {
+                    scheduleNetworkUpdate: false,
+                });
+                expect(client).to.be.instanceOf(NodeClient);
+                expect(client._shard).to.equal(1);
+                expect(client._realm).to.equal(2);
+            });
+
+            it("should throw error when nodes are in different shards", function () {
+                const nodes = {
+                    "0.testnet.hedera.com:50211": new AccountId(1, 2, 3),
+                    "34.94.106.61:50211": new AccountId(2, 2, 4),
+                };
+
+                expect(() =>
+                    NodeClient.forNetwork(nodes, {
+                        scheduleNetworkUpdate: false,
+                    }),
+                ).to.throw("All nodes must be within the same shard and realm");
+            });
+
+            it("should throw error when nodes are in different realms", function () {
+                const nodes = {
+                    "0.testnet.hedera.com:50211": new AccountId(1, 2, 0),
+                    "34.94.106.61:50211": new AccountId(1, 3, 1),
+                };
+
+                expect(() =>
+                    NodeClient.forNetwork(nodes, {
+                        scheduleNetworkUpdate: false,
+                    }),
+                ).to.throw("All nodes must be within the same shard and realm");
+            });
+
+            it("should use network node shard and realm values over explicitly provided values", function () {
+                const nodes = {
+                    "0.testnet.hedera.com:50211": new AccountId(1, 2, 3),
+                    "34.94.106.61:50211": new AccountId(1, 2, 4),
+                };
+
+                const client = NodeClient.forNetwork(nodes, {
+                    shard: 5,
+                    realm: 6,
+                    scheduleNetworkUpdate: false,
+                });
+
+                // Should use shard=1 and realm=2 from the network nodes
+                // instead of the explicitly provided shard=5 and realm=6
+                expect(client._shard).to.equal(1);
+                expect(client._realm).to.equal(2);
+            });
+        });
+    });
 });


### PR DESCRIPTION
**Description**:
Adds persistent realm and shard according to https://github.com/hiero-ledger/sdk-collaboration-hub/pull/28

### Changed
- `ClientConfiguration` type updated: The `Client` constructor now accepts `shard` and `realm` parameters directly.  
- `Client.forMirrorNetwork` now supports two additional arguments: `shard` and `realm`.
### Internal
- When a custom network is provided in the `Client` constructor, the `shard` and `realm` values are now automatically inferred from the specified network.
- An error is now thrown if the nodes defined in a custom network are not all in the same shard and realm, enforcing consistency and preventing misconfiguration.

Fixes https://github.com/hiero-ledger/hiero-sdk-js/issues/3153

Notes for reviewer:

Checklist

- [x]  Documented (Code comments, README, etc.)
- [x]  Tested (unit, integration, etc.)
