### PR TITLE
chore(release): v2.65.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.65.0
+## v2.65.1
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.65.0",
+    "version": "2.65.1",
     "description": "Hiero SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",
@@ -60,7 +60,7 @@
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/rlp": "^5.8.0",
         "@grpc/grpc-js": "^1.12.6",
-        "@hashgraph/cryptography": "1.7.3",
+        "@hashgraph/cryptography": "1.7.4",
         "@hashgraph/proto": "2.18.5",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/cryptography",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "Cryptographic utilities and primitives for the Hiero SDK",
     "main": "./lib/index.cjs",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
**Description**:
Stable release v2.65.1

## v2.65.1

### Added

-   Support for external transaction signing via HSM:
    -   Introduced `SignableNodeTransactionBodyBytes` to encapsulate `nodeAccountId`, `transactionId`, and canonical `bodyBytes`.
    -   Added `Transaction.signableNodeBodyBytesList()` API to return node-specific, signable transaction bytes for HSM workflows, enabling secure external signing and signature injection.
    -   Improves usability in enterprise and regulated environments. [#3119](https://github.com/hiero-ledger/hiero-sdk-js/pull/3119)
-   Test coverage for HSM-based signing added to the JavaScript SDK, including usage examples. [#3119](https://github.com/hiero-ledger/hiero-sdk-js/pull/3119)
-   Added a library to determine key type and updated relevant files to use the correct key type determination logic. [#3068](https://github.com/hiero-ledger/hiero-sdk-js/pull/3068)
-   Introduced transaction size getter for normal and chunked transactions. [#2961](https://github.com/hiero-ledger/hiero-sdk-js/pull/2961)

### Fixed

-   Regressions in `ContractCreateTransaction` and `TokenCreateTransaction` resolved. [#3125](https://github.com/hiero-ledger/hiero-sdk-js/pull/3125)

### Removed

-   Skipped batch transaction integration tests due to regressions. [#3125](https://github.com/hiero-ledger/hiero-sdk-js/pull/3125)

### Documentation

-   Added usage instructions in an example for HSM-based signing in SDK. [#3119](https://github.com/hiero-ledger/hiero-sdk-js/pull/3119)
-   Local command introduced for checking code coverage without relying on remote results. [#3116](https://github.com/hiero-ledger/hiero-sdk-js/pull/3116)

