### PR TITLE
chore(fix): Disabling `sideEffects` from the tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "sdk",
         "transactions"
     ],
-    "sideEffects": false,
+    "sideEffects": true,
     "files": [
         "lib/",
         "src/",


### PR DESCRIPTION
### Descriptipn
This PR disables tree shaking for specific modules that register transaction types via side-effectful calls (e.g., `TRANSACTION_REGISTRY.set()`). These registration calls are required at runtime but were previously being removed by tree shaking due to the `"sideEffects": false` setting in `package.json`.

### Context

Webpack tree shaking removes unused code based on import/export usage and `"sideEffects"` declarations. However, in our case, certain files contain essential side-effect calls that do not export anything directly. As a result, these were being incorrectly removed from the final bundle.

_Note: This is a temporary solution while we work on a more robust approach to support both tree shaking and the required side effects for registering transaction types._

Fixes #3011 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
