### PR TITLE
fix: setMaxGasAllowance is defined in hbars, not tinybars

### DIFF
--- a/src/EthereumFlow.js
+++ b/src/EthereumFlow.js
@@ -126,7 +126,7 @@ export default class EthereumFlow {
     }
 
     /**
-     * The maximum amount, in tinybars, that the payer of the hedera transaction
+     * The maximum amount, in hbars, that the payer of the hedera transaction
      * is willing to pay to complete the transaction.
      *
      * Ordinarily the account with the ECDSA alias corresponding to the public

--- a/src/EthereumTransaction.js
+++ b/src/EthereumTransaction.js
@@ -204,7 +204,7 @@ export default class EthereumTransaction extends Transaction {
     }
 
     /**
-     * The maximum amount, in tinybars, that the payer of the hedera transaction
+     * The maximum amount, in hbars, that the payer of the hedera transaction
      * is willing to pay to complete the transaction.
      *
      * Ordinarily the account with the ECDSA alias corresponding to the public


### PR DESCRIPTION
**Description**:

`setMaxGasAllowance` is defined in hbars, not tinybars.

**Related issue(s)**:

N/A

**Notes for reviewer**:

Unit tests already consider those values as hbars, see: https://github.com/hiero-ledger/hiero-sdk-js/blob/9951a906c235628d74c1bb85f1f30a3d47092da8/test/unit/EthereumTransaction.js#L18 and https://github.com/hiero-ledger/hiero-sdk-js/blob/9951a906c235628d74c1bb85f1f30a3d47092da8/test/unit/EthereumTransaction.js#L46

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
