### PR TITLE
chore(TCK): Glob method replacement

### DIFF
--- a/tck/methods/index.ts
+++ b/tck/methods/index.ts
@@ -1,10 +1,10 @@
-import glob from "glob";
+import { globSync } from "glob";
 import path from "path";
 
 // Require all files in this folder in one module.export
 
 let allMethods: Record<string, string> = {};
-glob.sync(path.join(__dirname, "**/*.ts")).forEach((file) => {
+globSync(path.join(__dirname, "**/*.ts")).forEach((file) => {
     allMethods = { ...allMethods, ...require(path.resolve(file)) };
 });
 


### PR DESCRIPTION
This PR fixes redundant `glob` method.
