### PR TITLE
chore: move `react-native-get-random-values` to peerDependencies

### DIFF
--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -65,7 +65,6 @@
         "crypto-js": "^4.2.0",
         "forge-light": "1.1.4",
         "js-base64": "^3.7.7",
-        "react-native-get-random-values": "^1.11.0",
         "spark-md5": "^3.0.2",
         "tweetnacl": "^1.0.3",
         "utf8": "^3.0.0"
@@ -73,7 +72,13 @@
     "peerDependenciesMeta": {
         "expo-crypto": {
             "optional": true
+        },
+        "react-native-get-random-values": {
+            "optional": true
         }
+    },
+    "peerDependencies": {
+        "react-native-get-random-values": "^1.11.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.27.0",


### PR DESCRIPTION
fix #3055