### PR TITLE
chore: move react-native-get-random-values to peerDependencies

### DIFF
--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -65,7 +65,6 @@
         "crypto-js": "^4.2.0",
         "forge-light": "1.1.4",
         "js-base64": "^3.7.7",
-        "react-native-get-random-values": "^1.11.0",
         "spark-md5": "^3.0.2",
         "tweetnacl": "^1.0.3",
         "utf8": "^3.0.0"
@@ -73,7 +72,13 @@
     "peerDependenciesMeta": {
         "expo-crypto": {
             "optional": true
+        },
+        "react-native-get-random-values": {
+            "optional": true
         }
+    },
+    "peerDependencies": {
+        "react-native-get-random-values": "^1.11.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.27.0",
@@ -93,7 +98,7 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-module-rewrite": "^0.2.0",
         "c8": "^10.1.3",
-        "chromedriver": "^138.0.0",
+        "chromedriver": "^137.0.0",
         "codecov": "^3.8.3",
         "dpdm": "^3.11.0",
         "eslint": "^8.52.0",
@@ -101,7 +106,7 @@
         "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-ie11": "^1.0.0",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jsdoc": "^51.3.1",
+        "eslint-plugin-jsdoc": "^50.6.9",
         "eslint-plugin-n": "^17.17.0",
         "eslint-plugin-vitest": "^0.5.4",
         "geckodriver": "^5.0.0",


### PR DESCRIPTION
**Original contributor: @ahmadi-akbar**

**Description**:
Makes `react-native-get-random-values` optional peer dependency.

Due to a problem with `pull` bot. I had to recreate #3201. 

**Related issue(s)**:
#3055

**Fixes**
#3055

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
