### PR TITLE
chore: Enable dual publishing in SDK_JS

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -344,22 +344,46 @@ jobs:
 
       - name: Publish Proto Release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_HG_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
+          NPM_HL_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         working-directory: packages/proto
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
-        run: task -v publish -- ${{ steps.proto-publish.outputs.args }}
+        run: |
+          NPM_TOKEN="${NPM_HG_TOKEN}"
+          task -v publish -- ${{ steps.proto-publish.outputs.args }}
+          cp package.json tmp.package.json
+          jq '.name |= sub("@hashgraph";"@hiero-ledger")' tmp.package.json > package.json
+          NPM_TOKEN="${NPM_HL_TOKEN}"
+          task -v publish -- ${{ steps.proto-publish.outputs.args }}
+          mv tmp.package.json package.json
 
       - name: Publish Cryptography Release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_HG_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
+          NPM_HL_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         working-directory: packages/cryptography
         if: ${{ needs.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
-        run: task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+        run: |
+          NPM_TOKEN="${NPM_HG_TOKEN}"
+          task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+          cp package.json tmp.package.json
+          jq '.name |= sub("@hashgraph";"@hiero-ledger")' tmp.package.json > package.json
+          NPM_TOKEN="${NPM_HL_TOKEN}"
+          task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+          mv tmp.package.json package.json
 
       - name: Publish SDK Release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          NPM_HG_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
+          NPM_HL_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
+        run: |
+          NPM_TOKEN="${NPM_HG_TOKEN}"
+          task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          cp package.json tmp.package.json
+          jq '.name |= sub("@hashgraph";"@hiero-ledger")' tmp.package.json > package.json
+          NPM_TOKEN="${NPM_HL_TOKEN}"
+          task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          mv tmp.package.json package.json
 
       - name: Generate Github Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0


### PR DESCRIPTION
## Important Notices

:rotating_light: NOT READY TO MERGE :rotating_light: 

:warning: TSC needs to approve dual publishing window before this PR is mergeable :warning:

## Description

This pull request updates the publishing workflow in `.github/workflows/publish_release.yaml` to support publishing packages under two different namespaces (`@hashgraph` and `@hiero-ledger`). The changes introduce additional environment variables and modify the publishing commands to handle namespace switching.

### Workflow Updates for Dual Namespace Publishing:

* **Environment Variables for Tokens**: Added `NPM_HG_TOKEN` and `NPM_HL_TOKEN` environment variables to replace the single `NPM_TOKEN` for publishing under different namespaces. (`[.github/workflows/publish_release.yamlL347-R386](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8L347-R386)`)

* **Namespace Switching Logic**: Updated the `run` commands for the `Publish Proto Release`, `Publish Cryptography Release`, and `Publish SDK Release` jobs to:
  - Use `jq` to modify the `package.json` file to switch the package name from the `@hashgraph` namespace to the `@hiero-ledger` namespace.
  - Publish the package under both namespaces by using the respective tokens. (`[.github/workflows/publish_release.yamlL347-R386](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8L347-R386)`)

### Related Issues

closes #3208

### Notes

- [ ] Tested
