### PR TITLE
fix: add validation for nodeId

### DIFF
--- a/src/node/NodeDeleteTransaction.js
+++ b/src/node/NodeDeleteTransaction.js
@@ -99,6 +99,21 @@ export default class NodeDeleteTransaction extends Transaction {
 
     /**
      * @override
+     * @param {?import("../client/Client.js").default<Channel, *>} client
+     * @returns {this}
+     */
+    freezeWith(client) {
+        if (this.nodeId == null) {
+            throw new Error(
+                "NodeDeleteTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        }
+
+        return super.freezeWith(client);
+    }
+
+    /**
+     * @override
      * @internal
      * @param {Channel} channel
      * @param {ITransaction} request

--- a/src/node/NodeUpdateTransaction.js
+++ b/src/node/NodeUpdateTransaction.js
@@ -480,6 +480,21 @@ export default class NodeUpdateTransaction extends Transaction {
 
     /**
      * @override
+     * @param {?import("../client/Client.js").default<Channel, *>} client
+     * @returns {this}
+     */
+    freezeWith(client) {
+        if (this.nodeId == null) {
+            throw new Error(
+                "NodeUpdateTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        }
+
+        return super.freezeWith(client);
+    }
+
+    /**
+     * @override
      * @internal
      * @param {Channel} channel
      * @param {ITransaction} request

--- a/test/unit/NodeDeleteTransaction.js
+++ b/test/unit/NodeDeleteTransaction.js
@@ -48,4 +48,58 @@ describe("NodeDeleteTransaction", function () {
         tx.setNodeId(421);
         expect(tx.nodeId).to.equal(421);
     });
+
+    describe("nodeId validation", function () {
+        const VALID_START = new Timestamp(1596210382, 0);
+        const ACCOUNT_ID = AccountId.fromString("0.6.9");
+        it("should freeze successfully when nodeId is set", function () {
+            const transaction = new NodeDeleteTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                )
+                .setNodeId(420);
+
+            expect(() => transaction.freeze()).to.not.throw();
+        });
+
+        it("should throw error when freezing without setting nodeId", function () {
+            const transaction = new NodeDeleteTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                );
+            // Note: nodeId is not set
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeDeleteTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        });
+
+        it("should throw error when freezing with null nodeId", function () {
+            const transaction = new NodeDeleteTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                )
+                .setNodeId(null);
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeDeleteTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        });
+
+        it("should throw error when freezing with undefined nodeId", function () {
+            const transaction = new NodeDeleteTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                )
+                .setNodeId(undefined);
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeDeleteTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        });
+    });
 });

--- a/test/unit/node/NodeUpdateTransaction.js
+++ b/test/unit/node/NodeUpdateTransaction.js
@@ -6,6 +6,7 @@ import {
     ServiceEndpoint,
     Timestamp,
     TransactionId,
+    Long,
 } from "../../../src/index.js";
 
 describe("NodeUpdateTransaction", function () {
@@ -210,6 +211,7 @@ describe("NodeUpdateTransaction", function () {
             const VALID_START = new Timestamp(1596210382, 0);
 
             tx = new NodeUpdateTransaction()
+                .setNodeId(Long.fromNumber(1))
                 .setNodeAccountIds([AccountId.fromString("0.0.3")])
                 .setTransactionId(
                     TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
@@ -355,6 +357,63 @@ describe("NodeUpdateTransaction", function () {
 
             expect(tx.grpcWebProxyEndpoint).to.be.null;
             expect(tx2.grpcWebProxyEndpoint).to.be.null;
+        });
+    });
+
+    describe("nodeId validation", function () {
+        const VALID_START = new Timestamp(1596210382, 0);
+        const ACCOUNT_ID = AccountId.fromString("0.6.9");
+        it("should freeze successfully when nodeId is set", function () {
+            const transaction = new NodeUpdateTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(
+                        AccountId.fromString("0.0.5006"),
+                        VALID_START,
+                    ),
+                )
+                .setNodeId(420);
+
+            expect(() => transaction.freeze()).to.not.throw();
+        });
+
+        it("should throw error when freezing without setting nodeId", function () {
+            const transaction = new NodeUpdateTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                );
+            // Note: nodeId is not set
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeUpdateTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        });
+
+        it("should throw error when freezing with null nodeId", function () {
+            const transaction = new NodeUpdateTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                )
+                .setNodeId(null);
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeUpdateTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
+        });
+
+        it("should throw error when freezing with undefined nodeId", function () {
+            const transaction = new NodeUpdateTransaction()
+                .setNodeAccountIds([AccountId.fromString("0.0.3")])
+                .setTransactionId(
+                    TransactionId.withValidStart(ACCOUNT_ID, VALID_START),
+                )
+                .setNodeId(undefined);
+
+            expect(() => transaction.freeze()).to.throw(
+                "NodeUpdateTransaction: 'nodeId' must be explicitly set before calling freeze().",
+            );
         });
     });
 });


### PR DESCRIPTION
**Description**:
This PR adds SDK-level validation to ensure the `nodeId` field is explicitly set in both `NodeUpdateTransaction` and `NodeDeleteTransaction` before execution. Without this check, the `nodeId` defaults to `0`, which can dangerously affect node `0.0.3` if not intended.
Add support for ...

### Fix Summary
- Throws an error if `nodeId` is not explicitly set prior to calling `execute()`.
- Prevents unintentional updates or deletes to node `0.0.3` caused by default protobuf behavior.

### Fixed
- Added validation to `NodeUpdateTransaction` and `NodeDeleteTransaction` ensuring that `nodeId` is explicitly set before execution. This prevents accidental updates to node `0.0.3` due to protobuf's default `uint64 = 0` behavior. 

**Related Issues**:
https://github.com/hiero-ledger/hiero-sdk-js/issues/3181

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
