### PR TITLE
fix: Clear methods in `TopicUpdateTransaction`

### DIFF
--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -439,12 +439,12 @@ export default class TopicUpdateTransaction extends Transaction {
     }
 
     /**
-     * Clears all keys that will be exempt from paying fees.
+     * Clears all keys that will be exempt from paying fees, effectively removing them from the network state.
      * @returns {this}
      */
     clearFeeExemptKeys() {
         this._requireNotFrozen();
-        this._feeExemptKeys = null;
+        this._feeExemptKeys = [];
 
         return this;
     }
@@ -542,13 +542,13 @@ export default class TopicUpdateTransaction extends Transaction {
     }
 
     /**
-     * Clears fixed fees.
+     * Clears fixed fees, effectively removing them from the network state.
      *
      * @returns {this}
      */
     clearCustomFees() {
         this._requireNotFrozen();
-        this._customFees = null;
+        this._customFees = [];
 
         return this;
     }

--- a/test/integration/TopicUpdateIntegrationTest.js
+++ b/test/integration/TopicUpdateIntegrationTest.js
@@ -90,8 +90,8 @@ describe("TopicUpdate", function () {
             // Update the topic and explicitly set fee exempt keys and custom fees to empty lists
             const updateResponse = await new TopicUpdateTransaction()
                 .setTopicId(topicId)
-                .setFeeExemptKeys([])
-                .setCustomFees([])
+                .clearCustomFees()
+                .clearFeeExemptKeys()
                 .execute(env.client);
 
             await updateResponse.getReceipt(env.client);

--- a/test/unit/TopicUpdateTransaction.js
+++ b/test/unit/TopicUpdateTransaction.js
@@ -94,7 +94,7 @@ describe("TopicUpdateTransaction", function () {
 
             topicUpdateTransaction.clearFeeExemptKeys();
 
-            expect(topicUpdateTransaction.getFeeExemptKeys()).to.be.null;
+            expect(topicUpdateTransaction.getFeeExemptKeys().length).to.eql(0);
         });
 
         it("should set topic custom fees", function () {
@@ -208,7 +208,7 @@ describe("TopicUpdateTransaction", function () {
 
             topicUpdateTransaction.clearCustomFees();
 
-            expect(topicUpdateTransaction.getCustomFees()).to.be.null;
+            expect(topicUpdateTransaction.getCustomFees().length).to.eql(0);
         });
 
         it("should not include feeExemptKeyList in transaction data when feeExemptKeys is null", function () {


### PR DESCRIPTION
**Description**:
This PR aligns clear methods for array properties in `TopicUpdateTransaction` to other SDKs, making these methods actually remove the arrays from the network state.

This inconsistency was found via TCK testing

**Related issue(s)**:

Related Issue #3240

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
