### PR TITLE
bug(ci): Fix dual publish errors with hiero subpackages

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -455,13 +455,15 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
             task -v publish -- ${{ steps.proto-publish.outputs.args }}
+        working-directory: packages/proto
 
-      - name: Publish SDK Release (@hiero-ledger/cryptography)
+      - name: Publish Cryptography Release (@hiero-ledger/cryptography)
         if: ${{ needs.validate-release.outputs.hiero-crypto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
-          task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+        working-directory: packages/cryptography
 
       - name: Publish SDK Release (@hiero-ledger/sdk)
         if: ${{ needs.validate-release.outputs.hiero-sdk-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}


### PR DESCRIPTION
**Description**:

The dual publish steps for the hiero subpackages were configured incorrectly. Needed to update the cryptography and proto subpackages to publish from the right package.json files.

**Related issue(s)**:

Fixes #3276

**Checklist**

- [ ] Tested [Link](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/16780431211) :runner:
