### PR TITLE
ci(bug): Fix DUAL_PUBLISH_ENABLED checks

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -164,6 +164,18 @@ jobs:
 
           echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
+      - name: Publish Required Summary
+        run: |
+          echo "## Publish Required Summary" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Package | Version | Publish Required |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "|---------|---------|------------------|" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hashgraph/sdk | ${{ steps.npm-package.outputs.sdk-version }} | ${{ steps.sdk-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hiero-ledger/sdk | ${{ steps.npm-package.outputs.sdk-version }} | ${{ steps.hiero-sdk-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hashgraph/proto | ${{ steps.npm-package.outputs.proto-version }} | ${{ steps.proto-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hiero-ledger/proto | ${{ steps.npm-package.outputs.proto-version }} | ${{ steps.hiero-proto-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hashgraph/cryptography | ${{ steps.npm-package.outputs.crypto-version }} | ${{ steps.crypto-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| @hiero-ledger/cryptography | ${{ steps.npm-package.outputs.crypto-version }} | ${{ steps.hiero-crypto-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Extract SDK Tag Information
         id: tag
         run: |

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -164,9 +164,9 @@ jobs:
 
           echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
-      - name: Publish Required Summary
+      - name: Package Version Summary
         run: |
-          echo "## Publish Required Summary" >> "${GITHUB_STEP_SUMMARY}"
+          echo "## Package Version Summary" >> "${GITHUB_STEP_SUMMARY}"
           echo "| Package | Version | Publish Required |" >> "${GITHUB_STEP_SUMMARY}"
           echo "|---------|---------|------------------|" >> "${GITHUB_STEP_SUMMARY}"
           echo "| @hashgraph/sdk | ${{ steps.npm-package.outputs.sdk-version }} | ${{ steps.sdk-required.outputs.publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-medium
     env:
       # Set the default to 'true' when the dual-publishing period is active
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || github.event_name == 'push' }}
     outputs:
       # Project tag
       tag: ${{ steps.tag.outputs.name }}
@@ -318,7 +318,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-large
     env:
       # Set the default to 'true' when the dual-publishing period is active
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || github.event_name == 'push' }}
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false'}}
     needs:
       - validate-release


### PR DESCRIPTION
## Description

This pull request updates the `publish_release.yaml` GitHub Actions workflow to improve usability and reporting. The main changes include simplifying the logic for enabling dual publishing and adding a step to generate a summary table of package versions and their publish status.

Workflow logic improvements:

* Simplified the `DUAL_PUBLISH_ENABLED` environment variable expression to remove the explicit comparison to `'true'`, making it more flexible and concise in both relevant jobs. [[1]](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8L37-R37) [[2]](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8L321-R333)

Reporting enhancements:

* Added a new step that generates a markdown summary table of package versions and whether publishing is required for each, outputting this to the GitHub Actions step summary.

**Related issue(s)**:

Fixes #3276 

