### PR TITLE
feat: bump node.js version in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-medium
     strategy:
       matrix:
-        node: [ "20", "22" ]
+        node: [ "22", "24" ]
 
     steps:
       - name: Harden Runner
@@ -66,7 +66,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-large
     strategy:
       matrix:
-        node: [ "20" ]
+        node: [ "22" ]
 
     steps:
       -  name: Harden Runner
@@ -171,7 +171,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-medium
     strategy:
       matrix:
-        node: [ "20" ]
+        node: [ "22" ]
     steps:
       -  name: Harden Runner
          uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/common_js.yml
+++ b/.github/workflows/common_js.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-large
     strategy:
       matrix:
-        node: [ "20", "22" ]
+        node: [ "22", "24" ]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       # Note: After Step-Security is enabled return to step-security/action-setup version
       - name: Install PNPM

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -319,7 +319,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Compile Code
         run: |
@@ -360,7 +360,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install NPM Dependencies

--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install PNPM
         uses: step-security/action-setup@598c7206e1c7d361165e303487aa7772566a8e05 # v4.1.0
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       # Note: After Step-Security is enabled return to step-security/action-setup version
       - name: Install PNPM

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "dist/"
     ],
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
     },
     "browserslist": [
         "> 0.5%",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "dist/"
     ],
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "browserslist": [
         "> 0.5%",

--- a/tck/Taskfile.yml
+++ b/tck/Taskfile.yml
@@ -7,8 +7,8 @@ tasks:
         cmds:
             - echo "Checking Node.js version..."
             - |
-                if ! command -v node &> /dev/null || [ "$(node -v | cut -d'.' -f1)" -lt "v20" ]; then
-                  echo "Node.js v20 or higher is required. Please install it."
+                if ! command -v node &> /dev/null || [ "$(node -v | cut -d'.' -f1)" -lt "v22" ]; then
+                  echo "Node.js v22 or higher is required. Please install it."
                   exit 1
                 fi
 


### PR DESCRIPTION
**Description**:
Node.js 20 is approaching end of life, but we are allowing the community additional time to migrate to a more recent release but we won't be bumping to `engine` property in `package.json` as this might be a breaking change for users. CI tests will now be executed on Node.js versions 22 and 24.

**Related issue(s)**:

#3242

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
