### PR TITLE
feat(TCK): add contract transactions endpoints

### DIFF
--- a/src/LedgerId.js
+++ b/src/LedgerId.js
@@ -40,11 +40,11 @@ export default class LedgerId {
             case "3":
                 return LedgerId.LOCAL_NODE;
             default: {
-                let ledgerIdDecoded = hex.decode(ledgerId);
-                if (ledgerIdDecoded.length == 0 && ledgerId.length != 0) {
-                    throw new Error("Default reached for fromString");
-                } else {
+                try {
+                    let ledgerIdDecoded = hex.decode(ledgerId);
                     return new LedgerId(ledgerIdDecoded);
+                } catch (error) {
+                    throw new Error("Default reached for fromString");
                 }
             }
         }

--- a/src/contract/ContractCreateTransaction.js
+++ b/src/contract/ContractCreateTransaction.js
@@ -378,7 +378,7 @@ export default class ContractCreateTransaction extends Transaction {
         this._requireNotFrozen();
         this._gas = gas instanceof Long ? gas : Long.fromValue(gas);
         if (this._gas.lessThan(0)) {
-            throw new Error("Gas must be greater than 0");
+            throw new Error("Gas cannot be negative number");
         }
         return this;
     }

--- a/src/contract/ContractCreateTransaction.js
+++ b/src/contract/ContractCreateTransaction.js
@@ -377,7 +377,9 @@ export default class ContractCreateTransaction extends Transaction {
     setGas(gas) {
         this._requireNotFrozen();
         this._gas = gas instanceof Long ? gas : Long.fromValue(gas);
-
+        if (this._gas.lessThan(0)) {
+            throw new Error("Gas must be greater than 0");
+        }
         return this;
     }
 
@@ -525,7 +527,7 @@ export default class ContractCreateTransaction extends Transaction {
             typeof stakedAccountId === "string"
                 ? AccountId.fromString(stakedAccountId)
                 : stakedAccountId;
-
+        this._stakedNodeId = null;
         return this;
     }
 
@@ -543,7 +545,7 @@ export default class ContractCreateTransaction extends Transaction {
     setStakedNodeId(stakedNodeId) {
         this._requireNotFrozen();
         this._stakedNodeId = Long.fromValue(stakedNodeId);
-
+        this._stakedAccountId = null;
         return this;
     }
 

--- a/src/contract/ContractDeleteTransaction.js
+++ b/src/contract/ContractDeleteTransaction.js
@@ -188,6 +188,7 @@ export default class ContractDeleteTransaction extends Transaction {
             transferContractId instanceof ContractId
                 ? transferContractId
                 : ContractId.fromString(transferContractId);
+        this._transferAccountId = null;
 
         return this;
     }

--- a/src/contract/ContractDeleteTransaction.js
+++ b/src/contract/ContractDeleteTransaction.js
@@ -224,6 +224,7 @@ export default class ContractDeleteTransaction extends Transaction {
             transferAccountId instanceof AccountId
                 ? transferAccountId
                 : AccountId.fromString(transferAccountId);
+        this._transferContractId = null;
 
         return this;
     }

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -10,7 +10,7 @@ import Duration from "../Duration.js";
 import Timestamp from "../Timestamp.js";
 import Key from "../Key.js";
 import Long from "long";
-import * as Proto from "@hashgraph/proto";
+import * as HieroProto from "@hashgraph/proto";
 
 /**
  * @namespace proto
@@ -644,7 +644,7 @@ export default class ContractUpdateTransaction extends Transaction {
             autoRenewAccountId:
                 this._autoRenewAccountId != null
                     ? this._autoRenewAccountId.toString() == "0.0.0"
-                        ? Proto.proto.AccountID.create()
+                        ? HieroProto.proto.AccountID.create()
                         : this._autoRenewAccountId._toProtobuf()
                     : null,
         };

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -10,6 +10,7 @@ import Duration from "../Duration.js";
 import Timestamp from "../Timestamp.js";
 import Key from "../Key.js";
 import Long from "long";
+import * as Proto from "@hashgraph/proto";
 
 /**
  * @namespace proto
@@ -642,7 +643,9 @@ export default class ContractUpdateTransaction extends Transaction {
                     : null,
             autoRenewAccountId:
                 this._autoRenewAccountId != null
-                    ? this._autoRenewAccountId._toProtobuf()
+                    ? this._autoRenewAccountId.toString() == "0.0.0"
+                        ? Proto.proto.AccountID.create()
+                        : this._autoRenewAccountId._toProtobuf()
                     : null,
         };
     }

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -10,7 +10,7 @@ import Duration from "../Duration.js";
 import Timestamp from "../Timestamp.js";
 import Key from "../Key.js";
 import Long from "long";
-import * as HieroProto from "@hashgraph/proto";
+import * as Proto from "@hashgraph/proto";
 
 /**
  * @namespace proto
@@ -644,7 +644,7 @@ export default class ContractUpdateTransaction extends Transaction {
             autoRenewAccountId:
                 this._autoRenewAccountId != null
                     ? this._autoRenewAccountId.toString() == "0.0.0"
-                        ? HieroProto.proto.AccountID.create()
+                        ? Proto.proto.AccountID.create()
                         : this._autoRenewAccountId._toProtobuf()
                     : null,
         };

--- a/src/encoding/hex.js
+++ b/src/encoding/hex.js
@@ -14,6 +14,26 @@ export function encode(data) {
  */
 export function decode(text) {
     const str = text.startsWith("0x") ? text.substring(2) : text;
+
+    if (str.length % 2 !== 0) {
+        throw new Error(
+            "Invalid hex string: Must have an even number of characters.",
+        );
+    }
+
+    if (/[^0-9a-fA-F]/.test(str)) {
+        throw new Error(
+            "Invalid hex string: Contains non-hexadecimal characters.",
+        );
+    }
+
+    const bytes = new Uint8Array(str.length / 2);
+
+    for (let i = 0; i < str.length; i += 2) {
+        const byte = parseInt(str.substring(i, i + 2), 16);
+        bytes[i / 2] = byte;
+    }
+
     return Buffer.from(str, "hex");
 }
 

--- a/tck/methods/contract.ts
+++ b/tck/methods/contract.ts
@@ -1,0 +1,230 @@
+import {
+    ContractCreateTransaction,
+    ContractDeleteTransaction,
+    ContractUpdateTransaction,
+    FileId,
+    Hbar,
+    Timestamp,
+} from "@hashgraph/sdk";
+
+import {
+    CreateContractParams,
+    DeleteContractParams,
+    UpdateContractParams,
+} from "../params/contract";
+import { ContractResponse } from "../response/contract";
+
+import { DEFAULT_GRPC_DEADLINE } from "../utils/constants/config";
+import { applyCommonTransactionParams } from "../params/common-tx-params";
+import { sdk } from "../sdk_data";
+import { getKeyFromString } from "../utils/key";
+import Long from "long";
+import { decode } from "../../src/encoding/hex.js";
+
+export const createContract = async ({
+    adminKey,
+    autoRenewPeriod,
+    autoRenewAccountId,
+    initialBalance,
+    bytecodeFileId,
+    initcode,
+    stakedAccountId,
+    stakedNodeId,
+    gas,
+    declineStakingReward,
+    memo,
+    maxAutomaticTokenAssociations,
+    constructorParameters,
+    commonTransactionParams,
+}: CreateContractParams): Promise<ContractResponse> => {
+    const transaction = new ContractCreateTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (adminKey != null) {
+        transaction.setAdminKey(getKeyFromString(adminKey));
+    }
+
+    if (autoRenewPeriod != null) {
+        transaction.setAutoRenewPeriod(Long.fromString(autoRenewPeriod));
+    }
+
+    if (gas != null) {
+        transaction.setGas(Long.fromString(gas));
+    }
+
+    if (autoRenewAccountId != null) {
+        transaction.setAutoRenewAccountId(autoRenewAccountId);
+    }
+
+    if (initialBalance != null) {
+        transaction.setInitialBalance(Hbar.fromTinybars(initialBalance));
+    }
+
+    if (initcode != null) {
+        const initCodeBuffer = decode(initcode);
+        transaction.setBytecode(initCodeBuffer);
+    }
+
+    if (bytecodeFileId != null) {
+        transaction.setBytecodeFileId(bytecodeFileId);
+    }
+
+    if (stakedAccountId != null) {
+        transaction.setStakedAccountId(stakedAccountId);
+    }
+
+    if (stakedNodeId != null) {
+        transaction.setStakedNodeId(Long.fromString(stakedNodeId));
+    }
+
+    if (declineStakingReward != null) {
+        transaction.setDeclineStakingReward(declineStakingReward);
+    }
+
+    if (memo != null) {
+        transaction.setContractMemo(memo);
+    }
+
+    if (maxAutomaticTokenAssociations != null) {
+        transaction.setMaxAutomaticTokenAssociations(
+            maxAutomaticTokenAssociations,
+        );
+    }
+
+    if (constructorParameters != null) {
+        const constructorParams = decode(constructorParameters);
+        transaction.setConstructorParameters(constructorParams);
+    }
+
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            sdk.getClient(),
+        );
+    }
+
+    const response = await transaction.execute(sdk.getClient());
+    const receipt = await response.getReceipt(sdk.getClient());
+
+    return {
+        contractId: receipt.contractId?.toString(),
+        status: receipt.status.toString(),
+    };
+};
+
+export const updateContract = async ({
+    contractId,
+    adminKey,
+    autoRenewPeriod,
+    autoRenewAccountId,
+    stakedAccountId,
+    stakedNodeId,
+    declineStakingReward,
+    memo,
+    maxAutomaticTokenAssociations,
+    expirationTime,
+    commonTransactionParams,
+}: UpdateContractParams): Promise<ContractResponse> => {
+    const transaction = new ContractUpdateTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (contractId != null) {
+        transaction.setContractId(contractId);
+    }
+
+    if (adminKey != null) {
+        transaction.setAdminKey(getKeyFromString(adminKey));
+    }
+
+    if (autoRenewPeriod != null) {
+        transaction.setAutoRenewPeriod(Long.fromString(autoRenewPeriod));
+    }
+
+    if (autoRenewAccountId != null) {
+        transaction.setAutoRenewAccountId(autoRenewAccountId);
+    }
+
+    if (stakedAccountId != null) {
+        transaction.setStakedAccountId(stakedAccountId);
+    }
+
+    if (stakedNodeId != null) {
+        transaction.setStakedNodeId(Long.fromString(stakedNodeId));
+    }
+
+    if (declineStakingReward != null) {
+        transaction.setDeclineStakingReward(declineStakingReward);
+    }
+
+    if (memo != null) {
+        transaction.setContractMemo(memo);
+    }
+
+    if (maxAutomaticTokenAssociations != null) {
+        transaction.setMaxAutomaticTokenAssociations(
+            maxAutomaticTokenAssociations,
+        );
+    }
+
+    if (expirationTime != null) {
+        transaction.setExpirationTime(
+            new Timestamp(Long.fromString(expirationTime), 0),
+        );
+    }
+
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            sdk.getClient(),
+        );
+    }
+
+    const response = await transaction.execute(sdk.getClient());
+    const receipt = await response.getReceipt(sdk.getClient());
+
+    return {
+        status: receipt.status.toString(),
+    };
+};
+
+export const deleteContract = async ({
+    contractId,
+    transferAccountId,
+    transferContractId,
+    commonTransactionParams,
+}: DeleteContractParams): Promise<ContractResponse> => {
+    const transaction = new ContractDeleteTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (contractId != null) {
+        transaction.setContractId(contractId);
+    }
+
+    if (transferAccountId != null) {
+        transaction.setTransferAccountId(transferAccountId);
+    }
+
+    if (transferContractId != null) {
+        transaction.setTransferContractId(transferContractId);
+    }
+
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            sdk.getClient(),
+        );
+    }
+
+    const response = await transaction.execute(sdk.getClient());
+    const receipt = await response.getReceipt(sdk.getClient());
+
+    return {
+        status: receipt.status.toString(),
+    };
+};

--- a/tck/methods/contract.ts
+++ b/tck/methods/contract.ts
@@ -205,12 +205,13 @@ export const deleteContract = async ({
         transaction.setContractId(contractId);
     }
 
-    if (transferAccountId != null) {
-        transaction.setTransferAccountId(transferAccountId);
-    }
-
+    //depend on how I order transferContractId and transferAccountId the last will stay if both are called
     if (transferContractId != null) {
         transaction.setTransferContractId(transferContractId);
+    }
+
+    if (transferAccountId != null) {
+        transaction.setTransferAccountId(transferAccountId);
     }
 
     if (commonTransactionParams != null) {

--- a/tck/methods/contract.ts
+++ b/tck/methods/contract.ts
@@ -195,6 +195,7 @@ export const deleteContract = async ({
     contractId,
     transferAccountId,
     transferContractId,
+    permanentRemoval,
     commonTransactionParams,
 }: DeleteContractParams): Promise<ContractResponse> => {
     const transaction = new ContractDeleteTransaction().setGrpcDeadline(
@@ -212,6 +213,10 @@ export const deleteContract = async ({
 
     if (transferAccountId != null) {
         transaction.setTransferAccountId(transferAccountId);
+    }
+
+    if (permanentRemoval != null) {
+        transaction.setPermanentRemoval(permanentRemoval);
     }
 
     if (commonTransactionParams != null) {

--- a/tck/methods/file.ts
+++ b/tck/methods/file.ts
@@ -31,7 +31,7 @@ export const createFile = async ({
         DEFAULT_GRPC_DEADLINE,
     );
 
-    if (keys.length > 0) {
+    if (keys?.length && keys.length > 0) {
         transaction.setKeys(keys.map((key: string) => getKeyFromString(key)));
     }
 

--- a/tck/params/contract.ts
+++ b/tck/params/contract.ts
@@ -34,5 +34,6 @@ export interface DeleteContractParams {
     readonly contractId: string;
     readonly transferAccountId?: string;
     readonly transferContractId?: string;
+    readonly permanentRemoval?: boolean;
     readonly commonTransactionParams?: Record<string, any>;
 }

--- a/tck/params/contract.ts
+++ b/tck/params/contract.ts
@@ -1,0 +1,38 @@
+export interface CreateContractParams {
+    readonly adminKey?: string;
+    readonly gas?: string;
+    readonly initialBalance?: string;
+    readonly initcode?: string;
+    readonly bytecodeFileId?: string;
+    readonly stakedAccountId?: string;
+    readonly stakedNodeId?: string;
+    readonly declineStakingReward?: boolean;
+    readonly autoRenewAccountId?: string;
+    readonly autoRenewPeriod?: string;
+    readonly automaticTokenAssociations?: boolean;
+    readonly constructorParameters?: string;
+    readonly memo?: string;
+    readonly maxAutomaticTokenAssociations?: number;
+    readonly commonTransactionParams?: Record<string, any>;
+}
+
+export interface UpdateContractParams {
+    readonly contractId: string;
+    readonly adminKey?: string;
+    readonly stakedAccountId?: string;
+    readonly stakedNodeId?: string;
+    readonly declineStakingReward?: boolean;
+    readonly autoRenewAccountId?: string;
+    readonly autoRenewPeriod?: string;
+    readonly memo?: string;
+    readonly maxAutomaticTokenAssociations?: number;
+    readonly expirationTime?: string;
+    readonly commonTransactionParams?: Record<string, any>;
+}
+
+export interface DeleteContractParams {
+    readonly contractId: string;
+    readonly transferAccountId?: string;
+    readonly transferContractId?: string;
+    readonly commonTransactionParams?: Record<string, any>;
+}

--- a/tck/response/contract.ts
+++ b/tck/response/contract.ts
@@ -1,0 +1,4 @@
+export interface ContractResponse {
+    readonly contractId?: string;
+    readonly status: string;
+}

--- a/test/unit/ContractDeleteTransaction.js
+++ b/test/unit/ContractDeleteTransaction.js
@@ -65,9 +65,7 @@ describe("ContractDeleteTransaction", function () {
             expect(transaction.contractId.toString()).to.equal(
                 contractId.toString(),
             );
-            expect(transaction.transferAccountId.toString()).to.equal(
-                transferAccountId.toString(),
-            );
+            expect(transaction.transferAccountId).to.be.null;
             expect(transaction.transferContractId.toString()).to.equal(
                 transferContractId.toString(),
             );
@@ -404,9 +402,7 @@ describe("ContractDeleteTransaction", function () {
             expect(deserializedDelete.contractId.toString()).to.equal(
                 contractId.toString(),
             );
-            expect(deserializedDelete.transferAccountId.toString()).to.equal(
-                transferAccountId.toString(),
-            );
+            expect(deserializedDelete.transferAccountId).to.be.null;
             expect(deserializedDelete.transferContractId.toString()).to.equal(
                 transferContractId.toString(),
             );


### PR DESCRIPTION
**Description**:
Implement Contract transaction for the TCK.

SDK changes:
- Makes `setStakedAccountID` and `setStakedNodeID` explicitly mutually exclusive. Setting one sets the other to null.
- Makes `setTransferAccountId` and `setTransferContractId` explicitly mutually exclusive. Setting one sets the other to null.
- Adds the ability to remove autorenew account in `ContractUpdate` via setting it to `0.0.0`
- Added check in `ContractCreateTransaction` to reject setting gas less than 0.
- Added validations in `hex.js` for decoding invalid hex strings.

