### PR TITLE
feat: add contract tests

### DIFF
--- a/test/unit/ContractCreateTransaction.js
+++ b/test/unit/ContractCreateTransaction.js
@@ -1,0 +1,44 @@
+import { AccountId, ContractCreateTransaction } from "../../src/index.js";
+import Long from "long";
+
+describe("ContractDeleteTransaction", function () {
+    let stakedAccountId;
+    let stakedNodeId;
+
+    beforeEach(function () {
+        stakedAccountId = new AccountId(0, 0, 3333);
+        stakedNodeId = Long.fromNumber(5);
+        // privateKey = PrivateKey.generateED25519();
+    });
+
+    it("should throw an error if gas is negative", function () {
+        const tx = new ContractCreateTransaction();
+
+        let err = false;
+        try {
+            tx.setGas(-1);
+        } catch (error) {
+            if (error.message.includes("Gas cannot be negative number"))
+                err = true;
+        }
+
+        expect(err).to.be.true;
+    });
+
+    it("should get the last called if both stakedAccountId and stakedNodeId are present", function () {
+        const tx = new ContractCreateTransaction({
+            stakedAccountId: stakedAccountId,
+            stakedNodeId: stakedNodeId,
+        });
+
+        expect(tx.stakedAccountId).to.be.null;
+        expect(tx.stakedNodeId.toString()).to.equal(stakedNodeId.toString());
+
+        tx.setStakedAccountId(stakedAccountId);
+
+        expect(tx.stakedAccountId.toString()).to.equal(
+            stakedAccountId.toString(),
+        );
+        expect(tx.stakedNodeId).to.be.null;
+    });
+});


### PR DESCRIPTION
**Description**:
Implement tests for Contract Create and Contract Update

Unit tests:
- negative gas
- call both both stakedAccountId and stakedNodeId


Integration tests:
- update the auto renew account ID to 0.0.0


