### PR TITLE
fix: Enhance PR check workflow with assignee validation

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,6 +1,5 @@
 name: 'PR Formatting'
 on:
-  workflow_dispatch:
   pull_request_target:
     types:
       - opened
@@ -14,6 +13,7 @@ defaults:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -22,10 +22,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: hiero-client-sdk-linux-medium
-    if: ${{ !github.event.pull_request.base.repo.fork }}
-    permissions:
-      statuses: write
+    runs-on: hiero-network-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -33,6 +30,22 @@ jobs:
           egress-policy: audit
 
       - name: Check PR Title
-        uses: step-security/conventional-pr-title-action@d47e8818876fa91d2010b65c4d699bb5f0d34d56 # v3.2.3
+        uses: step-security/conventional-pr-title-action@101b3d5adffb51b5789997fea508c8313c8ddf02 # v3.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  assignee-check:
+    name: Assignee Check
+    runs-on: hiero-network-node-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check Assignee
+        if: ${{ github.event.pull_request.assignees == null || github.event.pull_request.assignees[0] == null }}
+        run: |
+          echo "Assignee is not set. Failing the workflow."
+          exit 1


### PR DESCRIPTION
## Description

This pull request updates the PR formatting workflow configuration to improve permissions management, update runner environments, and add a new check for assignees on pull requests. The most important changes are grouped below:

Workflow configuration and permissions:

* Added `statuses: write` permission to the workflow to enable status updates for PR checks. (.github/workflows/pr_check.yml)
* Removed the `workflow_dispatch` trigger, making the workflow run only on pull request events. (.github/workflows/pr_check.yml)

Runner and job updates:

* Changed the runner environment for jobs from `hiero-client-sdk-linux-medium` to `hiero-network-node-linux-medium` for improved consistency and resource management. (.github/workflows/pr_check.yml)

PR validation enhancements:

* Added a new `assignee-check` job to ensure that every pull request has an assignee set, failing the workflow if not. (.github/workflows/pr_check.yml)

Dependency updates:

* Downgraded the `step-security/conventional-pr-title-action` action from v3.2.3 to v3.2.2 for the PR title check job. (.github/workflows/pr_check.yml)
