### PR TITLE
chore: Change runner type for PR checks to client SDK

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -36,7 +36,7 @@ jobs:
 
   assignee-check:
     name: Assignee Check
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hiero-client-sdk-linux-medium
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a different runner for the `title-check` and `assignee-check` jobs. The runner is changed from `hiero-network-node-linux-medium` to `hiero-client-sdk-linux-medium` to align with current infrastructure requirements.

Workflow configuration updates:

* Changed the runner for the `title-check` job in `.github/workflows/pr_check.yml` from `hiero-network-node-linux-medium` to `hiero-client-sdk-linux-medium`.
* Changed the runner for the `assignee-check` job in `.github/workflows/pr_check.yml` from `hiero-network-node-linux-medium` to `hiero-client-sdk-linux-medium`.
