### PR TITLE
ci(fix): Update authentication mechanism for NPM 22

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -380,9 +380,6 @@ jobs:
           [[ "${{ needs.validate-release.outputs.proto-prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.proto-type }}"
 
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
-
-          # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
         working-directory: packages/proto
 
       - name: Calculate Crypto Subpackage Publish Arguments
@@ -421,7 +418,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
         run: |
+          # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
+          cp .npmrc .npmrc.bkp
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.proto-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
         working-directory: packages/proto
 
       - name: Publish Cryptography Release (@hashgraph/cryptography)
@@ -429,7 +430,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
         run: |
+          cp .npmrc .npmrc.bkp
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
         working-directory: packages/cryptography
 
       - name: Publish SDK Release (@hashgraph/sdk)
@@ -437,7 +441,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
         run: |
+          cp .npmrc .npmrc.bkp
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
 
       - name: Update Files for Dual Publish
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
@@ -466,7 +473,8 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
-            task -v publish -- ${{ steps.proto-publish.outputs.args }}
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
+          task -v publish -- ${{ steps.proto-publish.outputs.args }}
         working-directory: packages/proto
 
       - name: Publish Cryptography Release (@hiero-ledger/cryptography)
@@ -474,6 +482,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.crypto-publish.outputs.args }}
         working-directory: packages/cryptography
 
@@ -482,6 +491,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 
       - name: Reset workspace

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -473,8 +473,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
+          cp .npmrc .npmrc.bkp
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.proto-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
         working-directory: packages/proto
 
       - name: Publish Cryptography Release (@hiero-ledger/cryptography)
@@ -482,8 +484,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
+          cp .npmrc .npmrc.bkp
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.crypto-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
         working-directory: packages/cryptography
 
       - name: Publish SDK Release (@hiero-ledger/sdk)
@@ -491,8 +495,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
         run: |
+          cp .npmrc .npmrc.bkp
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >>".npmrc"
           task -v publish -- ${{ steps.sdk-publish.outputs.args }}
+          cp .npmrc.bkp .npmrc
 
       - name: Reset workspace
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}


### PR DESCRIPTION
## Description

This pull request updates the release publishing workflow in `.github/workflows/publish_release.yaml` to improve the handling of npm authentication during package publishing. The main change is the introduction of a safer approach for modifying the `.npmrc` file by backing it up before adding the authentication token and restoring it afterwards, which helps prevent accidental overwrites or leakage of sensitive credentials.

**Improvements to npm authentication handling:**

* Added steps to back up the existing `.npmrc` file before appending the npm authentication token, and to restore it after publishing for all package publish jobs (`@hashgraph/proto`, `@hashgraph/cryptography`, `@hashgraph/sdk`, and their `@hiero-ledger` equivalents). This ensures the original configuration is preserved and sensitive data is not left behind. [[1]](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8R421-R447) [[2]](diffhunk://#diff-4f398b9d652dfd8c5f7eaa797dc903b64a3735a99002c81f795d877bc43b4ba8R476-R501)

* Removed the previous approach of directly appending the authentication token to `.npmrc` in the proto publish arguments calculation step, centralizing the authentication handling in the actual publish steps.
