### PR TITLE
refactor: move mirror rest api getter logic to mirror network

### DIFF
--- a/src/MirrorNode.js
+++ b/src/MirrorNode.js
@@ -38,4 +38,58 @@ export default class MirrorNode extends ManagedNode {
     getKey() {
         return this._address.toString();
     }
+
+    /**
+     * Gets the base URL for this mirror node's REST API.
+     *
+     * @returns {string} The base URL for the mirror node REST API
+     * @throws {Error} When the mirror node has invalid address configuration
+     */
+    get mirrorRestApiBaseUrl() {
+        const host = this.address.address;
+        const port = this.address.port;
+
+        if (!host || !port) {
+            throw new Error("Mirror node has invalid address configuration");
+        }
+
+        // For localhost/127.0.0.1, mirror node gRPC and REST API use different ports
+        // gRPC typically uses port 5600, but REST API uses port 5551
+        // Note: Contract calls may use port 8545 (handled separately in MirrorNodeContractQuery)
+        if (host === "localhost" || host === "127.0.0.1") {
+            return `http://${host}:5551/api/v1`;
+        }
+
+        const scheme = this._getSchemeFromHostAndPort(host, port);
+
+        return `${scheme}://${host}:${port}/api/v1`;
+    }
+
+    /**
+     * Determines the appropriate scheme (http/https) based on the host and port.
+     *
+     * @private
+     * @param {string} host - The host address
+     * @param {number} port - The port number
+     * @returns {string} - The scheme ('http' or 'https')
+     */
+    _getSchemeFromHostAndPort(host, port) {
+        // For localhost and 127.0.0.1, use HTTP scheme
+        if (host === "localhost" || host === "127.0.0.1") {
+            return "http";
+        }
+
+        // Standard HTTPS ports
+        if (port === 443) {
+            return "https";
+        }
+
+        // Standard HTTP ports
+        if (port === 80) {
+            return "http";
+        }
+
+        // For other ports, assume HTTPS for security
+        return "https";
+    }
 }

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -180,6 +180,7 @@ export default class AccountId {
             throw new Error("field `evmAddress` should not be null");
         }
         const mirrorRestApiBaseUrl = client.mirrorRestApiBaseUrl;
+        console.log("mirrorRestApiBaseUrl", mirrorRestApiBaseUrl);
 
         const url = `${mirrorRestApiBaseUrl}/accounts/${this.evmAddress.toString()}`;
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -272,26 +272,7 @@ export default class Client {
      * @throws {Error} When no mirror network is configured or available
      */
     get mirrorRestApiBaseUrl() {
-        try {
-            const mirrorNode = this._mirrorNetwork.getNextMirrorNode();
-            const host = mirrorNode.address.address;
-            const port = mirrorNode.address.port;
-
-            if (!host || !port) {
-                throw new Error(
-                    "Mirror node has invalid address configuration",
-                );
-            }
-
-            const scheme = this._getSchemeFromHostAndPort(host, port);
-
-            return `${scheme}://${host}:${port}/api/v1`;
-        } catch (error) {
-            // Re-throw with a more descriptive error message
-            throw new Error(
-                "Client has no mirror network configured or no healthy mirror nodes are available",
-            );
-        }
+        return this._mirrorNetwork.mirrorRestApiBaseUrl;
     }
 
     /**
@@ -839,34 +820,6 @@ export default class Client {
                 this._scheduleNetworkUpdate();
             }
         }, this._networkUpdatePeriod);
-    }
-
-    /**
-     * Determines the appropriate scheme (http/https) based on the host and port.
-     *
-     * @private
-     * @param {string} host - The host address
-     * @param {number} port - The port number
-     * @returns {string} - The scheme ('http' or 'https')
-     */
-    _getSchemeFromHostAndPort(host, port) {
-        // For localhost and 127.0.0.1, use HTTP scheme
-        if (host === "localhost" || host === "127.0.0.1") {
-            return "http";
-        }
-
-        // Standard HTTPS ports
-        if (port === 443) {
-            return "https";
-        }
-
-        // Standard HTTP ports
-        if (port === 80) {
-            return "http";
-        }
-
-        // For other ports, assume HTTPS for security
-        return "https";
     }
 
     /**

--- a/src/client/MirrorNetwork.js
+++ b/src/client/MirrorNetwork.js
@@ -84,4 +84,22 @@ export default class MirrorNetwork extends ManagedNetwork {
     getNextMirrorNode() {
         return this._getNumberOfMostHealthyNodes(1)[0];
     }
+
+    /**
+     * Gets the base URL for the mirror node REST API.
+     *
+     * @returns {string} The base URL for the mirror node REST API
+     * @throws {Error} When no mirror network is configured or available
+     */
+    get mirrorRestApiBaseUrl() {
+        try {
+            const mirrorNode = this.getNextMirrorNode();
+            return mirrorNode.mirrorRestApiBaseUrl;
+        } catch (error) {
+            // Re-throw with a more descriptive error message
+            throw new Error(
+                "Client has no mirror network configured or no healthy mirror nodes are available",
+            );
+        }
+    }
 }

--- a/src/query/MirrorNodeContractQuery.js
+++ b/src/query/MirrorNodeContractQuery.js
@@ -226,7 +226,8 @@ export default class MirrorNodeContractQuery {
         const isLocalEnvironment = host === "localhost" || host === "127.0.0.1";
 
         if (isLocalEnvironment) {
-            // For local environments, use HTTP scheme and port 8545
+            // For local environments, use HTTP scheme and port 8545 for contract calls
+            // (different from general mirror node REST API port 5551)
             const url = new URL(mirrorRestApiBaseUrl);
             url.protocol = "http:";
             url.port = "8545";

--- a/test/integration/AccountIdTest.js
+++ b/test/integration/AccountIdTest.js
@@ -1,4 +1,10 @@
-import { AccountId, TokenId } from "../../src/exports.js";
+import {
+    AccountId,
+    TokenId,
+    PrivateKey,
+    TransferTransaction,
+    Hbar,
+} from "../../src/exports.js";
 import IntegrationTestEnv, { Client } from "./client/NodeIntegrationTestEnv.js";
 
 describe("AccountId", function () {
@@ -43,6 +49,66 @@ describe("AccountId", function () {
 
         if (!err) {
             throw new Error("entity parsing did not err");
+        }
+    });
+
+    it.only("should populate account number from EVM address", async function () {
+        // Create a new integration test environment for this test
+        const env = await IntegrationTestEnv.new();
+
+        try {
+            // Generate a new ECDSA private key
+            const privateKey = PrivateKey.generateECDSA();
+            const publicKey = privateKey.publicKey;
+            const evmAddress = publicKey.toEvmAddress();
+
+            // Create AccountId from EVM address
+            const evmAddressAccount = AccountId.fromEvmAddress(
+                0,
+                0,
+                evmAddress,
+            );
+
+            // Transfer 1 Hbar to the EVM address account to create it
+            const transferTx = await new TransferTransaction()
+                .addHbarTransfer(evmAddressAccount, new Hbar(1))
+                .addHbarTransfer(env.operatorId, new Hbar(-1))
+                .execute(env.client);
+
+            // Get the receipt to find the new account ID (include children to get the account creation receipt)
+            const receipt = await transferTx
+                .getReceiptQuery()
+                .setIncludeChildren(true)
+                .setValidateStatus(true)
+                .execute(env.client);
+
+            // The new account ID should be in the first child receipt
+            const newAccountId = receipt.children[0].accountId;
+
+            // Create another AccountId from the same EVM address for testing populateAccountNum
+            const idMirror = AccountId.fromEvmAddress(0, 0, evmAddress);
+
+            // Wait a bit for the account to be available on mirror node
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            // Populate the account number using mirror node
+            const populatedAccountId = await idMirror.populateAccountNum(
+                env.client,
+            );
+
+            // Verify that the account number was populated correctly
+            expect(populatedAccountId.num.toString()).to.equal(
+                newAccountId.num.toString(),
+            );
+            expect(populatedAccountId.shard.toString()).to.equal(
+                newAccountId.shard.toString(),
+            );
+            expect(populatedAccountId.realm.toString()).to.equal(
+                newAccountId.realm.toString(),
+            );
+        } finally {
+            // Clean up the test environment
+            await env.close();
         }
     });
 

--- a/test/unit/node/NodeClient.js
+++ b/test/unit/node/NodeClient.js
@@ -363,7 +363,7 @@ describe("Client", function () {
             const mirrorRestApiBaseUrl = client.mirrorRestApiBaseUrl;
 
             expect(mirrorRestApiBaseUrl).to.equal(
-                "http://localhost:5600/api/v1",
+                "http://localhost:5551/api/v1",
             );
         });
 
@@ -378,7 +378,7 @@ describe("Client", function () {
             const mirrorRestApiBaseUrl = client.mirrorRestApiBaseUrl;
 
             expect(mirrorRestApiBaseUrl).to.equal(
-                "http://127.0.0.1:5600/api/v1",
+                "http://127.0.0.1:5551/api/v1",
             );
         });
 


### PR DESCRIPTION
**Description**:
This moves the mirrorRestApiBaseUrl construction from the client to the MirrorNode class for better separation of concerns.
Additional fix - port for the rest api is handled correctly for local dev environments.
