### PR TITLE
chore: update CODEOWNERS to reflect new maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*                                               @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/hiero-sdk-js-committers
+*                                               @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 #########################
 #####  Core Files  ######
@@ -12,19 +12,19 @@
 /.github/workflows/                             @hiero-ledger/github-maintainers
 
 # Codacy Tool Configurations
-/config/                                        @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-maintainers
-.remarkrc                                       @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/github-maintainers
+/config/                                        @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
+.remarkrc                                       @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/hiero-sdk-js-committers @hiero-ledger/tsc
-**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers @hiero-ledger/tsc
+**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/tsc
 
 # CodeCov configuration
 **/codecov.yml                                  @hiero-ledger/github-maintainers
 
 # Git Ignore definitions
-**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
-**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-js-maintainers @hiero-ledger/tsc
+**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/tsc
+**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/tsc


### PR DESCRIPTION
Please read hiero-ledger/governance#642

This change depends on
hiero-ledger/governance#649

**Description**:
Individual SDK teams in config.yaml should be merged into a single team

**Related issue(s)**:
Fixes hiero-ledger/governance#642
