### PR TITLE
test(integration): fix flaky Ethereum access-list roundtrip

### DIFF
--- a/test/integration/EthereumTransactionAccessListIntegrationTest.js
+++ b/test/integration/EthereumTransactionAccessListIntegrationTest.js
@@ -97,7 +97,27 @@ describe("EthereumTransactionAccessListIntegrationTest", function () {
     }
 
     /**
+     * Helper: strip leading zero bytes so a scalar is a canonical
+     * (minimally-encoded) RLP integer.
+     */
+    function toMinimalBytes(bytes) {
+        let start = 0;
+        while (start < bytes.length && bytes[start] === 0) {
+            start += 1;
+        }
+        return bytes.slice(start);
+    }
+
+    /**
      * Helper: sign a raw Ethereum message and return { v, r, s }.
+     *
+     * `r` and `s` are minimally encoded (leading zero bytes stripped) —
+     * Ethereum's canonical RLP integer form. `getRecoveryId` requires the
+     * fixed-width 32-byte scalars, so trimming happens after that call.
+     * Without trimming, a signature whose `r` or `s` starts with a zero
+     * byte (~1/128 of signatures) makes the hand-built transaction
+     * non-canonical and the byte-exact roundtrip against
+     * EthereumTransactionData.toBytes() flakily fails.
      */
     function signMessage(privateKey, message) {
         const signedBytes = privateKey.sign(message);
@@ -106,7 +126,7 @@ describe("EthereumTransactionAccessListIntegrationTest", function () {
         const s = signedBytes.slice(mid);
         const recoveryId = privateKey.getRecoveryId(r, s, message);
         const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
-        return { v, r, s };
+        return { v, r: toMinimalBytes(r), s: toMinimalBytes(s) };
     }
 
     it("EIP-1559 (type 2): access list reduces or matches gas usage", async function () {


### PR DESCRIPTION
## Description

The `EthereumTransactionAccessListIntegrationTest` roundtrip assertion `expect(txData.toBytes()).to.deep.equal(ethereumData2)` fails intermittently in CI, e.g. [this run](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/30984492329/job/92236042053) on an unrelated Dependabot PR (#4307):

```
AssertionError: expected Buffer[ 1, 249, 1, 6, … (266) ] to deeply equal Buffer[ 1, 249, 1, 7, … (267) ]
```

### Root cause

The test's `signMessage` helper splits the 64-byte compact ECDSA signature into fixed-width 32-byte `r`/`s` and RLP-encodes them verbatim with ethers' `encodeRlp`. When a signature scalar happens to start with a `0x00` byte (~1/128 of signatures), the hand-built transaction bytes contain a zero-padded, non-canonical scalar — while `EthereumTransactionData.toBytes()` (since #4186) re-encodes `r`/`s` minimally, as required by Ethereum's canonical RLP integer encoding. The re-encoded buffer is then one byte shorter and the byte-exact comparison fails.

All three tests in the file (EIP-1559, EIP-2930, and the skipped EIP-7702) share the helper, so each had the same latent flake.

### Fix

Strip leading zero bytes from `r`/`s` in the helper — after calling `getRecoveryId`, which requires the fixed-width scalars — so the hand-built transactions are canonically encoded, matching what real signers produce.

### Verification

Reproduced deterministically with a local script that loops signing until a scalar has a leading zero byte, then builds the type-1 transaction exactly like the test:

```
leading-zero scalar hit after 31 signatures (r[0]=47, s[0]=0)
old (padded) roundtrip equal: false (168 vs 169 bytes)
new (minimal) roundtrip equal: true (168 vs 168 bytes)
```

## Related issue(s)

Flaky failure observed on #4307 CI.

## Checklist

- [x] Tested (repro script above; `eslint` and `prettier` pass)