### PR TITLE
fix: replace AccountBalanceQuery ping probe with a COST_ANSWER query

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import AccountId from "../account/AccountId.js";
-import AccountBalanceQuery from "../account/AccountBalanceQuery.js";
+import AccountInfoQuery from "../account/AccountInfoQuery.js";
 import Hbar from "../Hbar.js";
 import Network from "./Network.js";
 import MirrorNetwork from "./MirrorNetwork.js";
@@ -867,16 +867,23 @@ export default class Client {
     }
 
     /**
+     * Probe the liveness of the node with the given account ID by sending a
+     * `CryptoService/getAccountInfo` query for account `<shard>.<realm>.2`
+     * with `ResponseType = COST_ANSWER` — the node answers with the query fee
+     * without executing the query, so no HBAR is charged and no operator is
+     * required. A cost response means success; a gRPC failure propagates.
+     *
      * @param {AccountId | string} accountId
      */
     async ping(accountId) {
-        await new AccountBalanceQuery({ accountId })
+        await new AccountInfoQuery()
+            .setAccountId(new AccountId(this._shard, this._realm, 2))
             .setNodeAccountIds([
                 accountId instanceof AccountId
                     ? accountId
                     : AccountId.fromString(accountId),
             ])
-            .execute(this);
+            .getCost(this);
     }
 
     async pingAll() {

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -63,20 +63,15 @@ export default class CostQuery extends QueryBase {
         const operator =
             this._operator != null ? this._operator : client._operator;
 
-        if (operator == null) {
-            throw new Error(
-                "`client` must have an `operator` or an explicit payment transaction must be provided",
-            );
-        }
-
         if (this._query._nodeAccountIds.isEmpty) {
             this._query._nodeAccountIds.setList(
                 client._network.getNodeAccountIdsForExecute(),
             );
         }
 
-        // operator.accountId
-        const transactionId = TransactionId.generate(operator.accountId);
+        const transactionId = TransactionId.generate(
+            operator != null ? operator.accountId : new AccountId(0),
+        );
         if (this._query.paymentTransactionId == null) {
             this._query.setPaymentTransactionId(transactionId);
         }
@@ -93,6 +88,10 @@ export default class CostQuery extends QueryBase {
             );
         }
 
+        // A COST_ANSWER query is answered free of charge, but the node still
+        // expects a payment transaction in the query header to pass
+        // validation. Without an operator the payment is left unsigned —
+        // the node checks its presence, not its signatures.
         this._header = {
             payment: await this._makePaymentTransaction(
                 paymentTransactionId,

--- a/test/unit/node/ClientPingMocking.js
+++ b/test/unit/node/ClientPingMocking.js
@@ -1,0 +1,123 @@
+import { AccountId } from "../../../src/index.js";
+import Mocker, { UNAVAILABLE } from "../Mocker.js";
+import Long from "long";
+import { proto } from "@hiero-ledger/proto";
+
+const PING_COST_RESPONSE = {
+    cryptoGetInfo: {
+        header: {
+            nodeTransactionPrecheckCode: 0,
+            responseType: proto.ResponseType.COST_ANSWER,
+            cost: Long.fromNumber(25),
+        },
+    },
+};
+
+describe("ClientPingMocking", function () {
+    let client;
+    let servers;
+
+    afterEach(function () {
+        client.close();
+        servers.close();
+    });
+
+    it("ping sends getAccountInfo for account 0.0.2 with COST_ANSWER", async function () {
+        ({ client, servers } = await Mocker.withResponses([
+            [
+                {
+                    call: (request) => {
+                        expect(request.cryptogetAccountBalance == null).to.be
+                            .true;
+
+                        const query = request.cryptoGetInfo;
+                        expect(query.header.responseType).to.equal(
+                            proto.ResponseType.COST_ANSWER,
+                        );
+                        expect(
+                            AccountId._fromProtobuf(query.accountID).toString(),
+                        ).to.equal("0.0.2");
+
+                        return PING_COST_RESPONSE;
+                    },
+                },
+            ],
+        ]));
+
+        await client.ping("0.0.3");
+    });
+
+    it("pingAll probes every node with the COST_ANSWER query", async function () {
+        const probed = [];
+        const makeResponse = () => ({
+            call: (request) => {
+                expect(request.cryptogetAccountBalance == null).to.be.true;
+                probed.push(request.cryptoGetInfo.header.responseType);
+                return PING_COST_RESPONSE;
+            },
+        });
+
+        ({ client, servers } = await Mocker.withResponses([
+            [makeResponse()],
+            [makeResponse()],
+        ]));
+
+        await client.pingAll();
+
+        expect(probed).to.deep.equal([
+            proto.ResponseType.COST_ANSWER,
+            proto.ResponseType.COST_ANSWER,
+        ]);
+    });
+
+    it("ping succeeds without an operator, attaching an unsigned payment", async function () {
+        ({ client, servers } = await Mocker.withResponses([
+            [
+                {
+                    call: (request) => {
+                        const header = request.cryptoGetInfo.header;
+                        expect(header.responseType).to.equal(
+                            proto.ResponseType.COST_ANSWER,
+                        );
+
+                        expect(header.payment).to.not.be.null;
+                        const signedTransaction =
+                            proto.SignedTransaction.decode(
+                                header.payment.signedTransactionBytes,
+                            );
+                        expect(signedTransaction.bodyBytes.length).to.be.gt(0);
+                        expect(
+                            signedTransaction.sigMap == null ||
+                                (signedTransaction.sigMap.sigPair ?? [])
+                                    .length === 0,
+                        ).to.be.true;
+
+                        return PING_COST_RESPONSE;
+                    },
+                },
+            ],
+        ]));
+
+        client._operator = null;
+
+        await client.ping(new AccountId(3));
+    });
+
+    it("ping rejects when the node fails at the gRPC layer", async function () {
+        ({ client, servers } = await Mocker.withResponses([
+            [{ error: UNAVAILABLE }],
+        ]));
+
+        client.setMaxAttempts(1);
+
+        let error = null;
+        try {
+            await client.ping("0.0.3");
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).to.be.an("Error");
+        expect(error.message).to.include("max attempts of 1 was reached");
+    });
+});


### PR DESCRIPTION
## Description

Stage 1 of the [AccountBalanceQuery deprecation proposal](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/account-balance-query-deprecation.md): the consensus node `CryptoService/cryptoGetBalance` endpoint is being throttled to zero in release 77 (testnet ≈ August 13, 2026), which would break the `AccountBalanceQuery`-based liveness probe inside `Client.ping()` / `Client.pingAll()` — and with it Solo readiness checks and connectivity tests.

### Changes

- `Client.ping()` now probes the node with a `CryptoService/getAccountInfo` query for account `<shard>.<realm>.2` with `ResponseType = COST_ANSWER` (via `AccountInfoQuery.getCost()`). The node returns the query fee without executing the query, so no HBAR is charged and the target account is irrelevant. A cost response is success; a gRPC-layer failure propagates, exactly as before. `pingAll()` keeps delegating to `ping()` per node, so node backoff behaviour is unchanged.
- `CostQuery` no longer requires an operator. The query header always carries a payment transaction — the node validates its presence for `COST_ANSWER` but never processes it — and it is simply left unsigned when no operator is configured. The signed path is byte-for-byte unchanged. This preserves `ping()`/`pingAll()` on operator-less clients (e.g. plain `Client.forNetwork(...)` connectivity checks) and makes `Query.getCost()` usable without an operator.
- New unit tests (`test/unit/node/ClientPingMocking.js`) covering the proposal's Stage 1 test plan: the probe sends `cryptoGetInfo` with `COST_ANSWER` for account `0.0.2` (and no `cryptogetAccountBalance`), a cost response resolves as success, `pingAll()` probes every node, an operator-less ping attaches an unsigned payment and succeeds, and a gRPC failure rejects.

No public API changes.

### Verification

- Full node unit suite passes (1931 tests), `tsc`, `eslint`, `prettier` clean.
- Local Solo (consensus node v0.73.0): `ClientIntegrationTest` 16/16 and `AccountInfoIntegrationTest` 5/5 pass; a direct operator-less `ping()`/`pingAll()` against the Solo node succeeds.
- Public testnet: operator-less `ping()` accepted by multiple nodes.

## Related issue(s)

Fixes #4305

## Checklist

- [x] Documented (JSDoc on `Client.ping()`)
- [x] Tested (unit + integration against Solo and testnet)
