### PR TITLE
test: stabilize flaky previewnet TLS and high-volume fee tests

### DIFF
--- a/test/integration/AccountBalanceIntegrationTest.js
+++ b/test/integration/AccountBalanceIntegrationTest.js
@@ -5,6 +5,27 @@ import IntegrationTestEnv, {
 } from "./client/NodeIntegrationTestEnv.js";
 import { createFungibleToken } from "./utils/Fixtures.js";
 
+/**
+ * Queries the balance of a node account, tolerating a BUSY precheck.
+ * Public networks throttle CI runner IPs, but a BUSY response still
+ * proves the TLS connection works — the node answered over it.
+ *
+ * @param {Client} client
+ * @param {import("../../src/exports.js").AccountId} nodeAccountId
+ */
+async function queryBalanceToleratingBusy(client, nodeAccountId) {
+    try {
+        await new AccountBalanceQuery()
+            .setAccountId(nodeAccountId)
+            .setMaxAttempts(3)
+            .execute(client);
+    } catch (error) {
+        if (!error.message.endsWith(Status.Busy.toString())) {
+            throw error;
+        }
+    }
+}
+
 describe("AccountBalanceQuery", function () {
     let clientPreviewNet;
     let clientTestnet;
@@ -33,10 +54,7 @@ describe("AccountBalanceQuery", function () {
         )) {
             expect(address.endsWith(":50212")).to.be.true;
 
-            await new AccountBalanceQuery()
-                .setAccountId(nodeAccountId)
-                .setMaxAttempts(10)
-                .execute(clientPreviewNet);
+            await queryBalanceToleratingBusy(clientPreviewNet, nodeAccountId);
         }
     });
 
@@ -50,10 +68,7 @@ describe("AccountBalanceQuery", function () {
         )) {
             expect(address.endsWith(":50212")).to.be.true;
 
-            await new AccountBalanceQuery()
-                .setAccountId(nodeAccountId)
-                .setMaxAttempts(10)
-                .execute(clientTestnet);
+            await queryBalanceToleratingBusy(clientTestnet, nodeAccountId);
         }
     });
 

--- a/test/integration/AccountCreateIntegrationTest.js
+++ b/test/integration/AccountCreateIntegrationTest.js
@@ -391,58 +391,70 @@ describe("AccountCreate", function () {
             expect(err).to.be.true;
         });
 
-        it("fee with setHighVolume(true) is different from fee with setHighVolume(false)", async function () {
-            const keyNormal = PrivateKey.generateED25519();
-            const keyHighVolume = PrivateKey.generateED25519();
+        // The browser and node suites share one CI runner, and the browser
+        // suite slows down heavily under contention — this test's sequential
+        // round trips need more than the default 120s there.
+        it(
+            "fee with setHighVolume(true) is different from fee with setHighVolume(false)",
+            { timeout: 240000 },
+            async function () {
+                const keyNormal = PrivateKey.generateED25519();
+                const keyHighVolume = PrivateKey.generateED25519();
 
-            const txNormal = await new AccountCreateTransaction()
-                .setKey(keyNormal.publicKey)
-                .setInitialBalance(new Hbar(1))
-                .setHighVolume(false)
-                .freezeWith(env.client)
-                .sign(keyNormal);
-            const responseNormal = await txNormal.execute(env.client);
-            const recordNormal = await responseNormal.getRecord(env.client);
-            const receiptNormal = await responseNormal.getReceipt(env.client);
-            const accountIdNormal = receiptNormal.accountId;
+                const txNormal = await new AccountCreateTransaction()
+                    .setKey(keyNormal.publicKey)
+                    .setInitialBalance(new Hbar(1))
+                    .setHighVolume(false)
+                    .freezeWith(env.client)
+                    .sign(keyNormal);
+                const responseNormal = await txNormal.execute(env.client);
+                const recordNormal = await responseNormal.getRecord(env.client);
+                const accountIdNormal = recordNormal.receipt.accountId;
 
-            const txHighVolume = await new AccountCreateTransaction()
-                .setKey(keyHighVolume.publicKey)
-                .setInitialBalance(new Hbar(1))
-                .setHighVolume(true)
-                .freezeWith(env.client)
-                .sign(keyHighVolume);
-            const responseHighVolume = await txHighVolume.execute(env.client);
-            const recordHighVolume = await responseHighVolume.getRecord(
-                env.client,
-            );
-            const receiptHighVolume = await responseHighVolume.getReceipt(
-                env.client,
-            );
-            const accountIdHighVolume = receiptHighVolume.accountId;
+                const txHighVolume = await new AccountCreateTransaction()
+                    .setKey(keyHighVolume.publicKey)
+                    .setInitialBalance(new Hbar(1))
+                    .setHighVolume(true)
+                    .freezeWith(env.client)
+                    .sign(keyHighVolume);
+                const responseHighVolume = await txHighVolume.execute(
+                    env.client,
+                );
+                const recordHighVolume = await responseHighVolume.getRecord(
+                    env.client,
+                );
+                const accountIdHighVolume = recordHighVolume.receipt.accountId;
 
-            const feeNormal = recordNormal.transactionFee.toTinybars();
-            const feeHighVolume = recordHighVolume.transactionFee.toTinybars();
-            expect(
-                !feeHighVolume.eq(feeNormal),
-                "fee with high-volume flag should differ from fee without flag",
-            ).to.be.true;
+                const feeNormal = recordNormal.transactionFee.toTinybars();
+                const feeHighVolume =
+                    recordHighVolume.transactionFee.toTinybars();
+                expect(
+                    !feeHighVolume.eq(feeNormal),
+                    "fee with high-volume flag should differ from fee without flag",
+                ).to.be.true;
 
-            await deleteAccount(env.client, keyNormal, (transaction) => {
-                transaction
-                    .setAccountId(accountIdNormal)
-                    .setTransferAccountId(env.operatorId)
-                    .setTransactionId(TransactionId.generate(accountIdNormal));
-            });
-            await deleteAccount(env.client, keyHighVolume, (transaction) => {
-                transaction
-                    .setAccountId(accountIdHighVolume)
-                    .setTransferAccountId(env.operatorId)
-                    .setTransactionId(
-                        TransactionId.generate(accountIdHighVolume),
-                    );
-            });
-        });
+                await deleteAccount(env.client, keyNormal, (transaction) => {
+                    transaction
+                        .setAccountId(accountIdNormal)
+                        .setTransferAccountId(env.operatorId)
+                        .setTransactionId(
+                            TransactionId.generate(accountIdNormal),
+                        );
+                });
+                await deleteAccount(
+                    env.client,
+                    keyHighVolume,
+                    (transaction) => {
+                        transaction
+                            .setAccountId(accountIdHighVolume)
+                            .setTransferAccountId(env.operatorId)
+                            .setTransactionId(
+                                TransactionId.generate(accountIdHighVolume),
+                            );
+                    },
+                );
+            },
+        );
 
         // TODO: fix this test
         // Flaky for now


### PR DESCRIPTION
## Description

Two integration tests fail intermittently for reasons unrelated to the code under test. Both bit repeatedly on 2026-08-10 (four red runs on [31094126592](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/31094126592) and the unrelated Dependabot run [31351017738](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/31351017738)).

### 1. `AccountBalanceQuery > can connect to previewnet/testnet with TLS` — BUSY exhausts retries

```
Error: max attempts of 10 was reached for request with last error being: BUSY
Serialized Error: { nodeAccountId: '0.0.4' }
```

**Root cause:** the tests query every public-network node, and previewnet routinely answers `BUSY` — during the 2026-08-10 incident all seven previewnet nodes returned `BUSY` for hours, from GitHub runners and independent networks alike. But a `BUSY` response is delivered over the established TLS channel — it already proves the connectivity the test exists to verify, so burning 10 retries (~58s) and failing CI on it is a false negative.

**Fix:** a shared helper tolerates a `BUSY`-tailed `MaxAttemptsOrTimeoutError` (any other error still fails the test) and drops `maxAttempts` from 10 to 3, so a throttled node costs ~2s instead of ~58s.

### 2. `chromium > AccountCreate > fee with setHighVolume(true) is different…` — 120s timeout

**Root cause:** the browser and node integration suites run in parallel on one runner, and the chromium suite degrades heavily under contention (e.g. 512s for the 18 FeeEstimateQuery tests in the same run). This test makes 8 sequential round trips through the grpc-web proxy, two of which are redundant — `getRecord` already fetches and embeds the receipt. Same timeout previously hit main on run [30989361281](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/30989361281).

**Fix:** derive the account IDs from `record.receipt.accountId` (removing the two redundant `getReceipt` round trips, the pattern already used in `TransactionResponseTest`) and give this test a 240s timeout.

## Related issue(s)

Flaky failures observed on #4312 CI (three consecutive attempts) and on Dependabot run 31351017738.

## Checklist

- [x] Tested (`eslint` and `prettier` pass; failure modes analyzed from CI logs of runs 31094126592, 31351017738, 30989361281)
