### PR TITLE
test: raise browser integration suite timeouts to 240s

### DIFF
--- a/test/vitest-browser-integration.config.ts
+++ b/test/vitest-browser-integration.config.ts
@@ -44,8 +44,11 @@ export default defineConfig({
             "test/integration/ClientIntegrationTest.js",
             "test/integration/dual-mode/**/*.js",
         ],
-        hookTimeout: 120000,
-        testTimeout: 120000,
+        // This suite runs concurrently with the node integration suite on a
+        // single CI runner and slows down several-fold under that contention,
+        // so it needs more headroom than the node suite's 120s.
+        hookTimeout: 240000,
+        testTimeout: 240000,
         coverage: {
             include: ["src/**/*.js"],
             exclude: [


### PR DESCRIPTION
## Description

The chromium integration suite shares a single CI runner with the concurrently-running node suite and degrades several-fold under that contention — e.g. `FeeEstimateQueryIntegrationTest` took **512s for 18 tests** in chromium vs ~90s in the node suite on the same run. With a 120s per-test budget, any chromium test with many sequential round trips flakes whenever the runner is loaded.

Distinct victims of this class, all with `Test timed out in 120000ms`:

- `AccountCreate > fee with setHighVolume(true)…` — run [31094126592](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/31094126592) (2026-08-10), addressed individually in #4318
- `FileAppend > should find max chunk size before TRANSACTION_OVERSIZE` — run [31379215664](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/31379215664) (2026-08-10)
- `TokenCancelAirdrop` tests (×3) — main run [30989361281](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/30989361281) (2026-08-05)

Raising `testTimeout`/`hookTimeout` to 240s for **only this suite** removes the whole class instead of patching one test at a time; genuinely hung tests still fail, just later. The node and dual-mode suites keep 120s — they haven't exhibited contention timeouts.

## Related issue(s)

Flaky timeouts on #4312 CI and main.

## Checklist

- [x] Tested (`prettier` passes; config-only change, failure class documented from CI logs)