### PR TITLE
feat(sdk): add MirrorNodeAccountBalanceQuery as mirror node replacement for AccountBalanceQuery

### DIFF
--- a/examples/account/get-balance-mirror-node.js
+++ b/examples/account/get-balance-mirror-node.js
@@ -1,0 +1,55 @@
+import {
+    AccountId,
+    Client,
+    MirrorNodeAccountBalanceQuery,
+    PrivateKey,
+} from "@hiero-ledger/sdk";
+
+import dotenv from "dotenv";
+
+dotenv.config();
+
+/**
+ * How to read an account balance from the mirror node REST API instead of the
+ * deprecated consensus-node `AccountBalanceQuery`.
+ *
+ * Note: the mirror node lags consensus by a few seconds, so a balance read
+ * right after a transfer may still show the pre-transfer value.
+ */
+async function main() {
+    if (
+        process.env.OPERATOR_ID == null ||
+        process.env.OPERATOR_KEY == null ||
+        process.env.HEDERA_NETWORK == null
+    ) {
+        throw new Error(
+            "Environment variables OPERATOR_ID, OPERATOR_KEY, and HEDERA_NETWORK are required.",
+        );
+    }
+
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    const operatorKey = PrivateKey.fromStringDer(process.env.OPERATOR_KEY);
+    const client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+        operatorId,
+        operatorKey,
+    );
+
+    try {
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(operatorId)
+            .execute(client);
+
+        console.log(
+            `${operatorId.toString()} balance = ${balance.hbars.toString()}`,
+        );
+        console.log(
+            `${operatorId.toString()} holds ${balance.tokens.size} token(s)`,
+        );
+    } catch (error) {
+        console.error(error);
+    }
+
+    client.close();
+}
+
+void main();

--- a/examples/account/get-balance-mirror-node.js
+++ b/examples/account/get-balance-mirror-node.js
@@ -42,9 +42,6 @@ async function main() {
         console.log(
             `${operatorId.toString()} balance = ${balance.hbars.toString()}`,
         );
-        console.log(
-            `${operatorId.toString()} holds ${balance.tokens.size} token(s)`,
-        );
     } catch (error) {
         console.error(error);
     }

--- a/src/account/MirrorNodeAccountBalance.js
+++ b/src/account/MirrorNodeAccountBalance.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @typedef {import("../Hbar.js").default} Hbar
+ */
+
+/**
+ * Read-only HBAR balance returned by `MirrorNodeAccountBalanceQuery`.
+ *
+ * Token balances are deliberately not included: the mirror node balances
+ * endpoint does not paginate them, and fetching a full token portfolio
+ * would require unbounded pagination against the mirror node. Use the
+ * mirror node token endpoints directly if token balances are needed.
+ */
+export default class MirrorNodeAccountBalance {
+    /**
+     * @param {object} props
+     * @param {Hbar} props.hbars
+     */
+    constructor(props) {
+        /**
+         * The HBAR balance of the account.
+         *
+         * @readonly
+         */
+        this.hbars = props.hbars;
+
+        Object.freeze(this);
+    }
+
+    /**
+     * @returns {string}
+     */
+    toString() {
+        return this.hbars.toString();
+    }
+}

--- a/src/exports.js
+++ b/src/exports.js
@@ -18,11 +18,12 @@ export { default as Mnemonic } from "./Mnemonic.js";
 export { default as TokenAirdropTransaction } from "./token/TokenAirdropTransaction.js";
 export { default as TokenClaimAirdropTransaction } from "./token/TokenClaimAirdropTransaction.js";
 export { default as TokenCancelAirdropTransaction } from "./token/TokenCancelAirdropTransaction.js";
- 
+
 export { default as AccountAllowanceApproveTransaction } from "./account/AccountAllowanceApproveTransaction.js";
 export { default as AccountAllowanceDeleteTransaction } from "./account/AccountAllowanceDeleteTransaction.js";
 export { default as AccountBalance } from "./account/AccountBalance.js";
 export { default as AccountBalanceQuery } from "./account/AccountBalanceQuery.js";
+export { default as MirrorNodeAccountBalanceQuery } from "./query/MirrorNodeAccountBalanceQuery.js";
 export { default as AccountCreateTransaction } from "./account/AccountCreateTransaction.js";
 export { default as AccountDeleteTransaction } from "./account/AccountDeleteTransaction.js";
 export { default as AccountId } from "./account/AccountId.js";
@@ -61,7 +62,7 @@ export { default as EthereumTransactionDataEip7702 } from "./EthereumTransaction
 export { default as EthereumTransactionData } from "./EthereumTransactionData.js";
 export { default as AccessListItem } from "./AccessListItem.js";
 export { default as Authorization } from "./Authorization.js";
- 
+
 export { default as EvmAddress } from "./EvmAddress.js";
 export { default as ExchangeRate } from "./ExchangeRate.js";
 export { default as ExchangeRates } from "./ExchangeRates.js";
@@ -101,9 +102,7 @@ export { default as FreezeTransaction } from "./system/FreezeTransaction.js";
 export { default as Hbar } from "./Hbar.js";
 export { default as HbarAllowance } from "./account/HbarAllowance.js";
 export { default as HbarUnit } from "./HbarUnit.js";
- 
- 
- 
+
 export { default as MaxQueryPaymentExceeded } from "./MaxQueryPaymentExceeded.js";
 export { default as MirrorNodeContractCallQuery } from "./query/MirrorNodeContractCallQuery.js";
 export { default as MirrorNodeContractEstimateQuery } from "./query/MirrorNodeContractEstimateQuery.js";
@@ -135,8 +134,7 @@ export { default as Signer } from "./Signer.js";
 export { default as SignerSignature } from "./SignerSignature.js";
 export { default as Status } from "./Status.js";
 export { default as SubscriptionHandle } from "./topic/SubscriptionHandle.js";
- 
- 
+
 export { default as Timestamp } from "./Timestamp.js";
 export { default as TokenAllowance } from "./account/TokenAllowance.js";
 export { default as TokenAssociateTransaction } from "./token/TokenAssociateTransaction.js";

--- a/src/exports.js
+++ b/src/exports.js
@@ -23,6 +23,7 @@ export { default as AccountAllowanceApproveTransaction } from "./account/Account
 export { default as AccountAllowanceDeleteTransaction } from "./account/AccountAllowanceDeleteTransaction.js";
 export { default as AccountBalance } from "./account/AccountBalance.js";
 export { default as AccountBalanceQuery } from "./account/AccountBalanceQuery.js";
+export { default as MirrorNodeAccountBalance } from "./account/MirrorNodeAccountBalance.js";
 export { default as MirrorNodeAccountBalanceQuery } from "./query/MirrorNodeAccountBalanceQuery.js";
 export { default as AccountCreateTransaction } from "./account/AccountCreateTransaction.js";
 export { default as AccountDeleteTransaction } from "./account/AccountDeleteTransaction.js";

--- a/src/query/MirrorNodeAccountBalanceQuery.js
+++ b/src/query/MirrorNodeAccountBalanceQuery.js
@@ -261,9 +261,12 @@ export default class MirrorNodeAccountBalanceQuery {
                     method: "GET",
                     cache: "no-store",
                     headers: { Accept: "application/json" },
-                    signal: client.requestTimeout
-                        ? AbortSignal.timeout(client.requestTimeout)
-                        : undefined,
+                    signal:
+                        client.requestTimeout &&
+                        typeof AbortSignal !== "undefined" &&
+                        typeof AbortSignal.timeout === "function"
+                            ? AbortSignal.timeout(client.requestTimeout)
+                            : undefined,
                 });
 
                 if (response.ok) {

--- a/src/query/MirrorNodeAccountBalanceQuery.js
+++ b/src/query/MirrorNodeAccountBalanceQuery.js
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import Long from "long";
+import AccountId from "../account/AccountId.js";
+import ContractId from "../contract/ContractId.js";
+import AccountBalance from "../account/AccountBalance.js";
+import TokenId from "../token/TokenId.js";
+import * as EntityIdHelper from "../EntityIdHelper.js";
+import {
+    isRetryableNetworkError,
+    readErrorDetail,
+} from "../network/mirrorRestRetry.js";
+
+/**
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
+ * @typedef {import("@hiero-ledger/proto").proto.ITokenBalance} ITokenBalance
+ */
+
+/**
+ * Relevant subset of `GET /api/v1/accounts/{id}`. The embedded
+ * `balance.tokens` array is a truncated preview and is deliberately not
+ * read here — the full token list comes from the `/tokens` sub-resource.
+ *
+ * @typedef {object} MirrorAccountResponse
+ * @property {?{balance: ?number}} balance
+ */
+
+/**
+ * One entry of `GET /api/v1/accounts/{id}/tokens`.
+ *
+ * @typedef {object} MirrorTokenRelationship
+ * @property {string} token_id
+ * @property {number} balance
+ * @property {?number} decimals
+ */
+
+/**
+ * Paging envelope of `GET /api/v1/accounts/{id}/tokens`.
+ *
+ * @typedef {object} MirrorAccountTokensResponse
+ * @property {?MirrorTokenRelationship[]} tokens
+ * @property {?{next: ?string}} links
+ */
+
+/**
+ * Initial retry backoff in milliseconds for transient mirror errors.
+ * @constant {number}
+ */
+const INITIAL_BACKOFF_MS = 250;
+
+/**
+ * Mirror-node REST replacement for the deprecated `AccountBalanceQuery`.
+ *
+ * Reads `GET /api/v1/accounts/{id}` for the hbar balance and
+ * `GET /api/v1/accounts/{id}/tokens` (following every page) for the token
+ * balances and decimals. Pure HTTP — no query payment, no node rotation,
+ * no gRPC — so this class deliberately does not extend `Query`.
+ *
+ * Accepts either an account ID or a contract ID; both are resolved through
+ * the mirror node's `accounts` endpoints, which accept contract IDs too.
+ * An `AccountId` carrying an `aliasKey` or an `evmAddress` is sent in the
+ * form the mirror node understands (base32 alias / bare EVM address)
+ * rather than `AccountId.toString()`.
+ *
+ * NOTE ON CONSISTENCY: the mirror node ingests consensus state
+ * asynchronously and typically lags the network by a few seconds. Results
+ * are therefore NOT read-after-write consistent — unlike the consensus-node
+ * `AccountBalanceQuery` this replaces, a balance read immediately after a
+ * transfer may still show the pre-transfer value.
+ */
+export default class MirrorNodeAccountBalanceQuery {
+    /**
+     * @param {object} [props]
+     * @param {AccountId | string} [props.accountId]
+     * @param {ContractId | string} [props.contractId]
+     */
+    constructor(props = {}) {
+        /**
+         * @private
+         * @type {?AccountId}
+         */
+        this._accountId = null;
+
+        /**
+         * @private
+         * @type {?ContractId}
+         */
+        this._contractId = null;
+
+        if (props.accountId != null) {
+            this.setAccountId(props.accountId);
+        }
+
+        if (props.contractId != null) {
+            this.setContractId(props.contractId);
+        }
+    }
+
+    /**
+     * @returns {?AccountId}
+     */
+    get accountId() {
+        return this._accountId;
+    }
+
+    /**
+     * Set the account whose balance to read. Mutually exclusive with
+     * `setContractId`.
+     *
+     * @param {AccountId | string} accountId
+     * @returns {this}
+     */
+    setAccountId(accountId) {
+        if (this._contractId != null) {
+            throw new Error(
+                "MirrorNodeAccountBalanceQuery accepts either an account ID or a contract ID, not both",
+            );
+        }
+
+        this._accountId =
+            typeof accountId === "string"
+                ? AccountId.fromString(accountId)
+                : accountId;
+        return this;
+    }
+
+    /**
+     * @returns {?ContractId}
+     */
+    get contractId() {
+        return this._contractId;
+    }
+
+    /**
+     * Set the contract whose balance to read. Mutually exclusive with
+     * `setAccountId`.
+     *
+     * @param {ContractId | string} contractId
+     * @returns {this}
+     */
+    setContractId(contractId) {
+        if (this._accountId != null) {
+            throw new Error(
+                "MirrorNodeAccountBalanceQuery accepts either an account ID or a contract ID, not both",
+            );
+        }
+
+        this._contractId =
+            typeof contractId === "string"
+                ? ContractId.fromString(contractId)
+                : contractId;
+        return this;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {Promise<AccountBalance>}
+     */
+    async execute(client) {
+        const idString = this._idString();
+        const baseUrl = client.mirrorRestApiBaseUrl;
+
+        const account = /** @type {MirrorAccountResponse} */ (
+            await this._fetchJson(`${baseUrl}/accounts/${idString}`, client)
+        );
+
+        /** @type {ITokenBalance[]} */
+        const tokenBalances = [];
+
+        let url = `${baseUrl}/accounts/${idString}/tokens`;
+        for (;;) {
+            const page = /** @type {MirrorAccountTokensResponse} */ (
+                await this._fetchJson(url, client)
+            );
+
+            for (const entry of page.tokens ?? []) {
+                tokenBalances.push({
+                    tokenId: TokenId.fromString(entry.token_id)._toProtobuf(),
+                    balance: Long.fromValue(entry.balance),
+                    decimals: entry.decimals != null ? entry.decimals : 0,
+                });
+            }
+
+            const next = page.links?.next;
+            if (next == null) {
+                break;
+            }
+            // `links.next` is a root-absolute path, so resolve it against
+            // the mirror node origin.
+            url = new URL(next, baseUrl).toString();
+        }
+
+        // `AccountBalance`'s constructor is private, so reuse the same
+        // internal factory the gRPC path uses; it owns the token
+        // balance/decimal map building.
+        return AccountBalance._fromProtobuf({
+            balance: Long.fromValue(account.balance?.balance ?? 0),
+            tokenBalances,
+        });
+    }
+
+    /**
+     * The path segment the mirror node expects for the configured ID.
+     *
+     * @private
+     * @returns {string}
+     */
+    _idString() {
+        if (this._accountId != null) {
+            const id = this._accountId;
+            if (id.aliasKey != null) {
+                // The mirror node only accepts the base32 alias; the DER hex
+                // that `AccountId.toString()` emits is rejected with a 400.
+                const alias = EntityIdHelper.publicKeyToAlias(id.aliasKey);
+                if (alias != null) {
+                    return alias;
+                }
+            }
+            if (id.evmAddress != null) {
+                return id.evmAddress.toString();
+            }
+            return id.toString();
+        }
+
+        if (this._contractId != null) {
+            const id = this._contractId;
+            if (id.evmAddress != null) {
+                return EntityIdHelper.toEvmAddress(id.evmAddress);
+            }
+            return id.toString();
+        }
+
+        throw new Error(
+            "MirrorNodeAccountBalanceQuery requires an account ID or a contract ID",
+        );
+    }
+
+    /**
+     * GET the URL and parse the JSON body, retrying transient failures
+     * (5xx, network/timeout) with exponential backoff. HTTP 4xx — an
+     * unknown or malformed ID — throws immediately.
+     *
+     * @private
+     * @param {string} url
+     * @param {Client} client
+     * @returns {Promise<unknown>}
+     */
+    async _fetchJson(url, client) {
+        const maxAttempts = client.maxAttempts;
+        const maxBackoff = client.maxBackoff;
+        let backoff = Math.min(INITIAL_BACKOFF_MS, maxBackoff);
+        /** @type {?Error} */
+        let lastError = null;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                // eslint-disable-next-line n/no-unsupported-features/node-builtins
+                const response = await fetch(url, {
+                    method: "GET",
+                    cache: "no-store",
+                    headers: { Accept: "application/json" },
+                    signal: client.requestTimeout
+                        ? AbortSignal.timeout(client.requestTimeout)
+                        : undefined,
+                });
+
+                if (response.ok) {
+                    const responseJson = /** @type {unknown} */ (
+                        await response.json()
+                    );
+                    return responseJson;
+                }
+
+                const detail = await readErrorDetail(response);
+                const error = new Error(
+                    `Failed to query ${url}: HTTP ${response.status}${
+                        detail ? `: ${detail}` : ""
+                    }`,
+                );
+
+                if (response.status >= 500 && attempt < maxAttempts) {
+                    lastError = error;
+                    await sleep(backoff);
+                    backoff = Math.min(backoff * 2, maxBackoff);
+                    continue;
+                }
+
+                throw error;
+            } catch (err) {
+                lastError = /** @type {Error} */ (err);
+                if (attempt < maxAttempts && isRetryableNetworkError(err)) {
+                    await sleep(backoff);
+                    backoff = Math.min(backoff * 2, maxBackoff);
+                    continue;
+                }
+                throw lastError;
+            }
+        }
+
+        throw lastError ?? new Error(`Failed to query ${url}`);
+    }
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/query/MirrorNodeAccountBalanceQuery.js
+++ b/src/query/MirrorNodeAccountBalanceQuery.js
@@ -179,7 +179,7 @@ export default class MirrorNodeAccountBalanceQuery {
                 tokenBalances.push({
                     tokenId: TokenId.fromString(entry.token_id)._toProtobuf(),
                     balance: Long.fromValue(entry.balance),
-                    decimals: entry.decimals != null ? entry.decimals : 0,
+                    decimals: entry.decimals ?? 0,
                 });
             }
 

--- a/src/query/MirrorNodeAccountBalanceQuery.js
+++ b/src/query/MirrorNodeAccountBalanceQuery.js
@@ -45,12 +45,6 @@ import {
  */
 
 /**
- * Initial retry backoff in milliseconds for transient mirror errors.
- * @constant {number}
- */
-const INITIAL_BACKOFF_MS = 250;
-
-/**
  * Mirror-node REST replacement for the deprecated `AccountBalanceQuery`.
  *
  * Reads `GET /api/v1/accounts/{id}` for the hbar balance and
@@ -69,6 +63,12 @@ const INITIAL_BACKOFF_MS = 250;
  * are therefore NOT read-after-write consistent — unlike the consensus-node
  * `AccountBalanceQuery` this replaces, a balance read immediately after a
  * transfer may still show the pre-transfer value.
+ *
+ * NOTE ON PRECISION: balances are parsed from JSON numbers, so values
+ * above `Number.MAX_SAFE_INTEGER` (2^53 - 1 tinybars, roughly 90M hbar;
+ * likewise raw token units) silently lose precision — unlike the
+ * protobuf-based `AccountBalanceQuery`. Lossless parsing is tracked as a
+ * follow-up.
  */
 export default class MirrorNodeAccountBalanceQuery {
     /**
@@ -156,14 +156,25 @@ export default class MirrorNodeAccountBalanceQuery {
 
     /**
      * @param {Client} client
+     * @param {number} [requestTimeout] - total timeout for the whole
+     * operation in milliseconds; defaults to `client.requestTimeout`
      * @returns {Promise<AccountBalance>}
      */
-    async execute(client) {
+    async execute(client, requestTimeout) {
         const idString = this._idString();
         const baseUrl = client.mirrorRestApiBaseUrl;
+        // One deadline for the whole operation (every page, every retry) —
+        // the timeout is a total operation budget, matching `Executable`,
+        // not a per-attempt bound.
+        const timeoutMs = requestTimeout ?? client.requestTimeout;
+        const deadline = timeoutMs != null ? Date.now() + timeoutMs : null;
 
         const account = /** @type {MirrorAccountResponse} */ (
-            await this._fetchJson(`${baseUrl}/accounts/${idString}`, client)
+            await this._fetchJson(
+                `${baseUrl}/accounts/${idString}`,
+                client,
+                deadline,
+            )
         );
 
         /** @type {ITokenBalance[]} */
@@ -172,7 +183,7 @@ export default class MirrorNodeAccountBalanceQuery {
         let url = `${baseUrl}/accounts/${idString}/tokens`;
         for (;;) {
             const page = /** @type {MirrorAccountTokensResponse} */ (
-                await this._fetchJson(url, client)
+                await this._fetchJson(url, client, deadline)
             );
 
             for (const entry of page.tokens ?? []) {
@@ -240,32 +251,47 @@ export default class MirrorNodeAccountBalanceQuery {
     /**
      * GET the URL and parse the JSON body, retrying transient failures
      * (5xx, network/timeout) with exponential backoff. HTTP 4xx — an
-     * unknown or malformed ID — throws immediately.
+     * unknown or malformed ID — throws immediately. `deadline` is the
+     * epoch-millisecond cutoff shared by every attempt of the whole
+     * operation.
      *
      * @private
      * @param {string} url
      * @param {Client} client
+     * @param {?number} deadline
      * @returns {Promise<unknown>}
      */
-    async _fetchJson(url, client) {
+    async _fetchJson(url, client, deadline) {
         const maxAttempts = client.maxAttempts;
         const maxBackoff = client.maxBackoff;
-        let backoff = Math.min(INITIAL_BACKOFF_MS, maxBackoff);
+        let backoff = Math.min(client.minBackoff, maxBackoff);
         /** @type {?Error} */
         let lastError = null;
 
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            const remaining = deadline != null ? deadline - Date.now() : null;
+            if (remaining != null && remaining <= 0) {
+                throw (
+                    lastError ??
+                    new Error(
+                        `Failed to query ${url}: request timeout exceeded`,
+                    )
+                );
+            }
+
             try {
                 // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 const response = await fetch(url, {
                     method: "GET",
                     cache: "no-store",
                     headers: { Accept: "application/json" },
+                    // Guarded because React Native's fetch polyfill does
+                    // not provide AbortSignal.timeout.
                     signal:
-                        client.requestTimeout &&
+                        remaining != null &&
                         typeof AbortSignal !== "undefined" &&
                         typeof AbortSignal.timeout === "function"
-                            ? AbortSignal.timeout(client.requestTimeout)
+                            ? AbortSignal.timeout(remaining)
                             : undefined,
                 });
 

--- a/src/query/MirrorNodeAccountBalanceQuery.js
+++ b/src/query/MirrorNodeAccountBalanceQuery.js
@@ -2,9 +2,8 @@
 
 import Long from "long";
 import AccountId from "../account/AccountId.js";
-import ContractId from "../contract/ContractId.js";
-import AccountBalance from "../account/AccountBalance.js";
-import TokenId from "../token/TokenId.js";
+import MirrorNodeAccountBalance from "../account/MirrorNodeAccountBalance.js";
+import Hbar from "../Hbar.js";
 import * as EntityIdHelper from "../EntityIdHelper.js";
 import {
     isRetryableNetworkError,
@@ -15,48 +14,30 @@ import {
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
  * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
- * @typedef {import("@hiero-ledger/proto").proto.ITokenBalance} ITokenBalance
  */
 
 /**
- * Relevant subset of `GET /api/v1/accounts/{id}`. The embedded
- * `balance.tokens` array is a truncated preview and is deliberately not
- * read here — the full token list comes from the `/tokens` sub-resource.
+ * Relevant subset of `GET /api/v1/balances`.
  *
- * @typedef {object} MirrorAccountResponse
- * @property {?{balance: ?number}} balance
- */
-
-/**
- * One entry of `GET /api/v1/accounts/{id}/tokens`.
- *
- * @typedef {object} MirrorTokenRelationship
- * @property {string} token_id
- * @property {number} balance
- * @property {?number} decimals
- */
-
-/**
- * Paging envelope of `GET /api/v1/accounts/{id}/tokens`.
- *
- * @typedef {object} MirrorAccountTokensResponse
- * @property {?MirrorTokenRelationship[]} tokens
- * @property {?{next: ?string}} links
+ * @typedef {object} MirrorBalancesResponse
+ * @property {?{account: string, balance: number}[]} balances
  */
 
 /**
  * Mirror-node REST replacement for the deprecated `AccountBalanceQuery`.
  *
- * Reads `GET /api/v1/accounts/{id}` for the hbar balance and
- * `GET /api/v1/accounts/{id}/tokens` (following every page) for the token
- * balances and decimals. Pure HTTP — no query payment, no node rotation,
- * no gRPC — so this class deliberately does not extend `Query`.
+ * Reads the HBAR balance from `GET /api/v1/balances?account.id={id}`.
+ * Pure HTTP — no query payment, no node rotation, no gRPC — so this class
+ * deliberately does not extend `Query`.
  *
- * Accepts either an account ID or a contract ID; both are resolved through
- * the mirror node's `accounts` endpoints, which accept contract IDs too.
+ * `setAccountId` accepts everything the mirror node resolves:
+ * `shard.realm.num`, an EVM address, a public key alias, or a contract ID.
  * An `AccountId` carrying an `aliasKey` or an `evmAddress` is sent in the
  * form the mirror node understands (base32 alias / bare EVM address)
  * rather than `AccountId.toString()`.
+ *
+ * Token balances are deliberately not returned (see
+ * {@link MirrorNodeAccountBalance}).
  *
  * NOTE ON CONSISTENCY: the mirror node ingests consensus state
  * asynchronously and typically lags the network by a few seconds. Results
@@ -64,17 +45,15 @@ import {
  * `AccountBalanceQuery` this replaces, a balance read immediately after a
  * transfer may still show the pre-transfer value.
  *
- * NOTE ON PRECISION: balances are parsed from JSON numbers, so values
- * above `Number.MAX_SAFE_INTEGER` (2^53 - 1 tinybars, roughly 90M hbar;
- * likewise raw token units) silently lose precision — unlike the
- * protobuf-based `AccountBalanceQuery`. Lossless parsing is tracked as a
- * follow-up.
+ * NOTE ON PRECISION: the balance is parsed from a JSON number, so values
+ * above `Number.MAX_SAFE_INTEGER` (2^53 - 1 tinybars, roughly 90M hbar)
+ * silently lose precision — unlike the protobuf-based
+ * `AccountBalanceQuery`. Lossless parsing is tracked as a follow-up.
  */
 export default class MirrorNodeAccountBalanceQuery {
     /**
      * @param {object} [props]
      * @param {AccountId | string} [props.accountId]
-     * @param {ContractId | string} [props.contractId]
      */
     constructor(props = {}) {
         /**
@@ -83,18 +62,8 @@ export default class MirrorNodeAccountBalanceQuery {
          */
         this._accountId = null;
 
-        /**
-         * @private
-         * @type {?ContractId}
-         */
-        this._contractId = null;
-
         if (props.accountId != null) {
             this.setAccountId(props.accountId);
-        }
-
-        if (props.contractId != null) {
-            this.setContractId(props.contractId);
         }
     }
 
@@ -106,19 +75,13 @@ export default class MirrorNodeAccountBalanceQuery {
     }
 
     /**
-     * Set the account whose balance to read. Mutually exclusive with
-     * `setContractId`.
+     * Set the account whose balance to read. Contract IDs are accepted
+     * too — the mirror node balances endpoint resolves them.
      *
      * @param {AccountId | string} accountId
      * @returns {this}
      */
     setAccountId(accountId) {
-        if (this._contractId != null) {
-            throw new Error(
-                "MirrorNodeAccountBalanceQuery accepts either an account ID or a contract ID, not both",
-            );
-        }
-
         this._accountId =
             typeof accountId === "string"
                 ? AccountId.fromString(accountId)
@@ -127,131 +90,71 @@ export default class MirrorNodeAccountBalanceQuery {
     }
 
     /**
-     * @returns {?ContractId}
-     */
-    get contractId() {
-        return this._contractId;
-    }
-
-    /**
-     * Set the contract whose balance to read. Mutually exclusive with
-     * `setAccountId`.
-     *
-     * @param {ContractId | string} contractId
-     * @returns {this}
-     */
-    setContractId(contractId) {
-        if (this._accountId != null) {
-            throw new Error(
-                "MirrorNodeAccountBalanceQuery accepts either an account ID or a contract ID, not both",
-            );
-        }
-
-        this._contractId =
-            typeof contractId === "string"
-                ? ContractId.fromString(contractId)
-                : contractId;
-        return this;
-    }
-
-    /**
      * @param {Client} client
      * @param {number} [requestTimeout] - total timeout for the whole
      * operation in milliseconds; defaults to `client.requestTimeout`
-     * @returns {Promise<AccountBalance>}
+     * @returns {Promise<MirrorNodeAccountBalance>}
      */
     async execute(client, requestTimeout) {
         const idString = this._idString();
         const baseUrl = client.mirrorRestApiBaseUrl;
-        // One deadline for the whole operation (every page, every retry) —
-        // the timeout is a total operation budget, matching `Executable`,
+        // One deadline for the whole operation (every retry) — the
+        // timeout is a total operation budget, matching `Executable`,
         // not a per-attempt bound.
         const timeoutMs = requestTimeout ?? client.requestTimeout;
         const deadline = timeoutMs != null ? Date.now() + timeoutMs : null;
 
-        const account = /** @type {MirrorAccountResponse} */ (
+        const response = /** @type {MirrorBalancesResponse} */ (
             await this._fetchJson(
-                `${baseUrl}/accounts/${idString}`,
+                `${baseUrl}/balances?account.id=${encodeURIComponent(
+                    idString,
+                )}`,
                 client,
                 deadline,
             )
         );
 
-        /** @type {ITokenBalance[]} */
-        const tokenBalances = [];
+        // The balances endpoint returns an empty array (not a 404) for an
+        // account that does not exist; the balance is zero in that case.
+        const balance = response.balances?.[0]?.balance ?? 0;
 
-        let url = `${baseUrl}/accounts/${idString}/tokens`;
-        for (;;) {
-            const page = /** @type {MirrorAccountTokensResponse} */ (
-                await this._fetchJson(url, client, deadline)
-            );
-
-            for (const entry of page.tokens ?? []) {
-                tokenBalances.push({
-                    tokenId: TokenId.fromString(entry.token_id)._toProtobuf(),
-                    balance: Long.fromValue(entry.balance),
-                    decimals: entry.decimals ?? 0,
-                });
-            }
-
-            const next = page.links?.next;
-            if (next == null) {
-                break;
-            }
-            // `links.next` is a root-absolute path, so resolve it against
-            // the mirror node origin.
-            url = new URL(next, baseUrl).toString();
-        }
-
-        // `AccountBalance`'s constructor is private, so reuse the same
-        // internal factory the gRPC path uses; it owns the token
-        // balance/decimal map building.
-        return AccountBalance._fromProtobuf({
-            balance: Long.fromValue(account.balance?.balance ?? 0),
-            tokenBalances,
+        return new MirrorNodeAccountBalance({
+            hbars: Hbar.fromTinybars(Long.fromValue(balance)),
         });
     }
 
     /**
-     * The path segment the mirror node expects for the configured ID.
+     * The `account.id` value the mirror node expects for the configured ID.
      *
      * @private
      * @returns {string}
      */
     _idString() {
-        if (this._accountId != null) {
-            const id = this._accountId;
-            if (id.aliasKey != null) {
-                // The mirror node only accepts the base32 alias; the DER hex
-                // that `AccountId.toString()` emits is rejected with a 400.
-                const alias = EntityIdHelper.publicKeyToAlias(id.aliasKey);
-                if (alias != null) {
-                    return alias;
-                }
-            }
-            if (id.evmAddress != null) {
-                return id.evmAddress.toString();
-            }
-            return id.toString();
+        if (this._accountId == null) {
+            throw new Error(
+                "MirrorNodeAccountBalanceQuery requires an account ID",
+            );
         }
 
-        if (this._contractId != null) {
-            const id = this._contractId;
-            if (id.evmAddress != null) {
-                return EntityIdHelper.toEvmAddress(id.evmAddress);
+        const id = this._accountId;
+        if (id.aliasKey != null) {
+            // The mirror node only accepts the base32 alias; the DER hex
+            // that `AccountId.toString()` emits is rejected with a 400.
+            const alias = EntityIdHelper.publicKeyToAlias(id.aliasKey);
+            if (alias != null) {
+                return alias;
             }
-            return id.toString();
         }
-
-        throw new Error(
-            "MirrorNodeAccountBalanceQuery requires an account ID or a contract ID",
-        );
+        if (id.evmAddress != null) {
+            return id.evmAddress.toString();
+        }
+        return id.toString();
     }
 
     /**
      * GET the URL and parse the JSON body, retrying transient failures
-     * (5xx, network/timeout) with exponential backoff. HTTP 4xx — an
-     * unknown or malformed ID — throws immediately. `deadline` is the
+     * (5xx, network/timeout) with exponential backoff. HTTP 4xx — a
+     * malformed ID — throws immediately. `deadline` is the
      * epoch-millisecond cutoff shared by every attempt of the whole
      * operation.
      *

--- a/test/integration/MirrorNodeAccountBalanceQuery.js
+++ b/test/integration/MirrorNodeAccountBalanceQuery.js
@@ -1,0 +1,69 @@
+import {
+    AccountId,
+    MirrorNodeAccountBalanceQuery,
+    TokenCreateTransaction,
+} from "../../src/exports.js";
+import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+
+// Cross-environment sleep function
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("MirrorNodeAccountBalanceQuery", function () {
+    let env;
+
+    beforeAll(async function () {
+        env = await IntegrationTestEnv.new();
+    });
+
+    it("should return the hbar balance of the operator account", async function () {
+        await sleep(5000);
+
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(env.operatorId)
+            .execute(env.client);
+
+        expect(balance.hbars.toTinybars().toNumber()).to.be.gt(0);
+    });
+
+    it("should return the token balance and decimals of the treasury", async function () {
+        const response = await new TokenCreateTransaction()
+            .setTokenName("ffff")
+            .setTokenSymbol("F")
+            .setDecimals(3)
+            .setInitialSupply(1000000)
+            .setTreasuryAccountId(env.operatorId)
+            .setAdminKey(env.operatorKey.publicKey)
+            .setSupplyKey(env.operatorKey.publicKey)
+            .setAutoRenewAccountId(env.operatorId)
+            .execute(env.client);
+
+        const tokenId = (await response.getReceipt(env.client)).tokenId;
+
+        await sleep(5000);
+
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(env.operatorId)
+            .execute(env.client);
+
+        expect(balance.tokens.get(tokenId).toNumber()).to.eql(1000000);
+        expect(balance.tokenDecimals.get(tokenId)).to.eql(3);
+    });
+
+    it("should reject a non-existent account", async function () {
+        let message = "";
+
+        try {
+            await new MirrorNodeAccountBalanceQuery()
+                .setAccountId(new AccountId(999999999))
+                .execute(env.client);
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(message).to.include("404");
+    });
+
+    afterAll(async function () {
+        await env.close();
+    });
+});

--- a/test/integration/MirrorNodeAccountBalanceQueryIntegrationTest.js
+++ b/test/integration/MirrorNodeAccountBalanceQueryIntegrationTest.js
@@ -8,6 +8,37 @@ import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 // Cross-environment sleep function
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Poll the mirror node until `fn` resolves to a truthy value, retrying
+ * both rejections (the entity is not ingested yet, so the mirror returns
+ * 404) and falsy results, up to a deadline. Fixed sleeps flake on slow
+ * CI runners; polling does not.
+ *
+ * @template T
+ * @param {() => Promise<T | null>} fn
+ * @param {number} [timeoutMs]
+ * @returns {Promise<T>}
+ */
+const untilMirror = async (fn, timeoutMs = 60000) => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        try {
+            const result = await fn();
+            if (result) {
+                return result;
+            }
+            if (Date.now() >= deadline) {
+                throw new Error("mirror node did not ingest in time");
+            }
+        } catch (error) {
+            if (Date.now() >= deadline) {
+                throw error;
+            }
+        }
+        await sleep(2000);
+    }
+};
+
 describe("MirrorNodeAccountBalanceQuery", function () {
     let env;
 
@@ -16,11 +47,12 @@ describe("MirrorNodeAccountBalanceQuery", function () {
     });
 
     it("should return the hbar balance of the operator account", async function () {
-        await sleep(5000);
-
-        const balance = await new MirrorNodeAccountBalanceQuery()
-            .setAccountId(env.operatorId)
-            .execute(env.client);
+        const balance = await untilMirror(async () => {
+            const result = await new MirrorNodeAccountBalanceQuery()
+                .setAccountId(env.operatorId)
+                .execute(env.client);
+            return result.hbars.toTinybars().toNumber() > 0 ? result : null;
+        });
 
         expect(balance.hbars.toTinybars().toNumber()).to.be.gt(0);
     });
@@ -39,11 +71,12 @@ describe("MirrorNodeAccountBalanceQuery", function () {
 
         const tokenId = (await response.getReceipt(env.client)).tokenId;
 
-        await sleep(5000);
-
-        const balance = await new MirrorNodeAccountBalanceQuery()
-            .setAccountId(env.operatorId)
-            .execute(env.client);
+        const balance = await untilMirror(async () => {
+            const result = await new MirrorNodeAccountBalanceQuery()
+                .setAccountId(env.operatorId)
+                .execute(env.client);
+            return result.tokens.get(tokenId) != null ? result : null;
+        });
 
         expect(balance.tokens.get(tokenId).toNumber()).to.eql(1000000);
         expect(balance.tokenDecimals.get(tokenId)).to.eql(3);

--- a/test/integration/MirrorNodeAccountBalanceQueryIntegrationTest.js
+++ b/test/integration/MirrorNodeAccountBalanceQueryIntegrationTest.js
@@ -1,8 +1,4 @@
-import {
-    AccountId,
-    MirrorNodeAccountBalanceQuery,
-    TokenCreateTransaction,
-} from "../../src/exports.js";
+import { AccountId, MirrorNodeAccountBalanceQuery } from "../../src/exports.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 
 // Cross-environment sleep function
@@ -10,9 +6,8 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Poll the mirror node until `fn` resolves to a truthy value, retrying
- * both rejections (the entity is not ingested yet, so the mirror returns
- * 404) and falsy results, up to a deadline. Fixed sleeps flake on slow
- * CI runners; polling does not.
+ * both rejections and falsy results, up to a deadline. Fixed sleeps flake
+ * on slow CI runners; polling does not.
  *
  * @template T
  * @param {() => Promise<T | null>} fn
@@ -57,43 +52,12 @@ describe("MirrorNodeAccountBalanceQuery", function () {
         expect(balance.hbars.toTinybars().toNumber()).to.be.gt(0);
     });
 
-    it("should return the token balance and decimals of the treasury", async function () {
-        const response = await new TokenCreateTransaction()
-            .setTokenName("ffff")
-            .setTokenSymbol("F")
-            .setDecimals(3)
-            .setInitialSupply(1000000)
-            .setTreasuryAccountId(env.operatorId)
-            .setAdminKey(env.operatorKey.publicKey)
-            .setSupplyKey(env.operatorKey.publicKey)
-            .setAutoRenewAccountId(env.operatorId)
+    it("should return zero hbars for a non-existent account", async function () {
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(new AccountId(999999999))
             .execute(env.client);
 
-        const tokenId = (await response.getReceipt(env.client)).tokenId;
-
-        const balance = await untilMirror(async () => {
-            const result = await new MirrorNodeAccountBalanceQuery()
-                .setAccountId(env.operatorId)
-                .execute(env.client);
-            return result.tokens.get(tokenId) != null ? result : null;
-        });
-
-        expect(balance.tokens.get(tokenId).toNumber()).to.eql(1000000);
-        expect(balance.tokenDecimals.get(tokenId)).to.eql(3);
-    });
-
-    it("should reject a non-existent account", async function () {
-        let message = "";
-
-        try {
-            await new MirrorNodeAccountBalanceQuery()
-                .setAccountId(new AccountId(999999999))
-                .execute(env.client);
-        } catch (error) {
-            message = error.message;
-        }
-
-        expect(message).to.include("404");
+        expect(balance.hbars.toTinybars().toNumber()).to.equal(0);
     });
 
     afterAll(async function () {

--- a/test/unit/MirrorNodeAccountBalanceQuery.js
+++ b/test/unit/MirrorNodeAccountBalanceQuery.js
@@ -3,10 +3,9 @@
 import sinon from "sinon";
 import {
     AccountId,
-    ContractId,
+    MirrorNodeAccountBalance,
     MirrorNodeAccountBalanceQuery,
     PublicKey,
-    TokenId,
 } from "../../src/exports.js";
 import { Client } from "../../src/index.js";
 import * as EntityIdHelper from "../../src/EntityIdHelper.js";
@@ -14,35 +13,9 @@ import * as EntityIdHelper from "../../src/EntityIdHelper.js";
 const MIRROR_HOST = "mirror.example.com";
 const BASE_URL = `https://${MIRROR_HOST}:443/api/v1`;
 
-/**
- * The mirror node's `/accounts/{id}` response. `balance.tokens` is a
- * truncated preview and must be ignored in favour of `/tokens`.
- */
-const ACCOUNT_RESPONSE = {
-    account: "0.0.123",
-    balance: {
-        balance: 5000000000,
-        timestamp: "1234567890.000000001",
-        tokens: [{ token_id: "0.0.999", balance: 1 }],
-    },
-    links: { next: "/api/v1/accounts/0.0.123?timestamp=lt:1234567890" },
-};
-
-const TOKENS_RESPONSE = {
-    tokens: [
-        {
-            token_id: "0.0.111",
-            balance: 250,
-            decimals: 3,
-            automatic_association: true,
-        },
-        {
-            token_id: "0.0.222",
-            balance: 7,
-            decimals: 0,
-            automatic_association: false,
-        },
-    ],
+const BALANCES_RESPONSE = {
+    timestamp: "1234567890.000000001",
+    balances: [{ account: "0.0.123", balance: 5000000000 }],
     links: { next: null },
 };
 
@@ -61,15 +34,10 @@ describe("MirrorNodeAccountBalanceQuery", function () {
     beforeEach(function () {
         originalFetch = globalObject().fetch;
 
-        fetchStub = sinon.stub().callsFake((url) => {
-            const body = url.includes("/tokens")
-                ? TOKENS_RESPONSE
-                : ACCOUNT_RESPONSE;
-            return Promise.resolve({
-                ok: true,
-                status: 200,
-                json: () => Promise.resolve(body),
-            });
+        fetchStub = sinon.stub().resolves({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(BALANCES_RESPONSE),
         });
 
         globalObject().fetch = fetchStub;
@@ -100,38 +68,11 @@ describe("MirrorNodeAccountBalanceQuery", function () {
         ).to.equal("0.0.123");
     });
 
-    it("should accept a ContractId instance and a string", function () {
-        const id = new ContractId(456);
-
-        expect(
-            new MirrorNodeAccountBalanceQuery().setContractId(id).contractId,
-        ).to.equal(id);
-        expect(
-            new MirrorNodeAccountBalanceQuery()
-                .setContractId("0.0.456")
-                .contractId.toString(),
-        ).to.equal("0.0.456");
-    });
-
     it("should throw on a malformed id without performing a request", function () {
         expect(() =>
             new MirrorNodeAccountBalanceQuery().setAccountId("not-an-id"),
         ).to.throw();
         expect(fetchStub.called).to.be.false;
-    });
-
-    it("should reject an account id and a contract id at the same time", function () {
-        expect(() =>
-            new MirrorNodeAccountBalanceQuery()
-                .setAccountId("0.0.123")
-                .setContractId("0.0.456"),
-        ).to.throw(/either an account ID or a contract ID/);
-
-        expect(() =>
-            new MirrorNodeAccountBalanceQuery()
-                .setContractId("0.0.456")
-                .setAccountId("0.0.123"),
-        ).to.throw(/either an account ID or a contract ID/);
     });
 
     it("should reject when no id is set", async function () {
@@ -141,30 +82,18 @@ describe("MirrorNodeAccountBalanceQuery", function () {
         } catch (error) {
             message = error.message;
         }
-        expect(message).to.include("requires an account ID or a contract ID");
+        expect(message).to.include("requires an account ID");
         expect(fetchStub.called).to.be.false;
     });
 
-    it("should query the accounts endpoint by shard.realm.num", async function () {
+    it("should query the balances endpoint by shard.realm.num", async function () {
         await new MirrorNodeAccountBalanceQuery()
             .setAccountId("0.0.123")
             .execute(client);
 
+        expect(fetchStub.calledOnce).to.be.true;
         expect(fetchStub.firstCall.args[0]).to.equal(
-            `${BASE_URL}/accounts/0.0.123`,
-        );
-        expect(fetchStub.secondCall.args[0]).to.equal(
-            `${BASE_URL}/accounts/0.0.123/tokens`,
-        );
-    });
-
-    it("should query a contract id through the accounts endpoint", async function () {
-        await new MirrorNodeAccountBalanceQuery()
-            .setContractId("0.0.456")
-            .execute(client);
-
-        expect(fetchStub.firstCall.args[0]).to.equal(
-            `${BASE_URL}/accounts/0.0.456`,
+            `${BASE_URL}/balances?account.id=0.0.123`,
         );
     });
 
@@ -176,7 +105,7 @@ describe("MirrorNodeAccountBalanceQuery", function () {
             .execute(client);
 
         expect(fetchStub.firstCall.args[0]).to.equal(
-            `${BASE_URL}/accounts/${evmAddress}`,
+            `${BASE_URL}/balances?account.id=${evmAddress}`,
         );
     });
 
@@ -193,31 +122,43 @@ describe("MirrorNodeAccountBalanceQuery", function () {
 
         expect(alias).to.not.be.null;
         expect(fetchStub.firstCall.args[0]).to.equal(
-            `${BASE_URL}/accounts/${alias}`,
+            `${BASE_URL}/balances?account.id=${alias}`,
         );
     });
 
-    it("should return the hbar, token and decimal balances", async function () {
+    it("should return the hbar balance", async function () {
         const balance = await new MirrorNodeAccountBalanceQuery()
             .setAccountId("0.0.123")
             .execute(client);
 
+        expect(balance).to.be.instanceOf(MirrorNodeAccountBalance);
         expect(balance.hbars.toTinybars().toString()).to.equal("5000000000");
+    });
 
-        // The `/tokens` endpoint wins — the truncated `balance.tokens`
-        // preview (0.0.999) must not appear.
-        expect(balance.tokens.get(TokenId.fromString("0.0.999"))).to.be.null;
-        expect(
-            balance.tokens.get(TokenId.fromString("0.0.111")).toString(),
-        ).to.equal("250");
-        expect(
-            balance.tokens.get(TokenId.fromString("0.0.222")).toString(),
-        ).to.equal("7");
-        expect(
-            balance.tokenDecimals.get(TokenId.fromString("0.0.111")),
-        ).to.equal(3);
-        expect(
-            balance.tokenDecimals.get(TokenId.fromString("0.0.222")),
-        ).to.equal(0);
+    it("should return zero hbars for an empty balances array", async function () {
+        fetchStub.resolves({
+            ok: true,
+            status: 200,
+            json: () =>
+                Promise.resolve({
+                    timestamp: null,
+                    balances: [],
+                    links: { next: null },
+                }),
+        });
+
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(balance.hbars.toTinybars().toString()).to.equal("0");
+    });
+
+    it("should be immutable", async function () {
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(Object.isFrozen(balance)).to.be.true;
     });
 });

--- a/test/unit/MirrorNodeAccountBalanceQuery.js
+++ b/test/unit/MirrorNodeAccountBalanceQuery.js
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import sinon from "sinon";
+import {
+    AccountId,
+    ContractId,
+    MirrorNodeAccountBalanceQuery,
+    PublicKey,
+    TokenId,
+} from "../../src/exports.js";
+import { Client } from "../../src/index.js";
+import * as EntityIdHelper from "../../src/EntityIdHelper.js";
+
+const MIRROR_HOST = "mirror.example.com";
+const BASE_URL = `https://${MIRROR_HOST}:443/api/v1`;
+
+/**
+ * The mirror node's `/accounts/{id}` response. `balance.tokens` is a
+ * truncated preview and must be ignored in favour of `/tokens`.
+ */
+const ACCOUNT_RESPONSE = {
+    account: "0.0.123",
+    balance: {
+        balance: 5000000000,
+        timestamp: "1234567890.000000001",
+        tokens: [{ token_id: "0.0.999", balance: 1 }],
+    },
+    links: { next: "/api/v1/accounts/0.0.123?timestamp=lt:1234567890" },
+};
+
+const TOKENS_RESPONSE = {
+    tokens: [
+        {
+            token_id: "0.0.111",
+            balance: 250,
+            decimals: 3,
+            automatic_association: true,
+        },
+        {
+            token_id: "0.0.222",
+            balance: 7,
+            decimals: 0,
+            automatic_association: false,
+        },
+    ],
+    links: { next: null },
+};
+
+describe("MirrorNodeAccountBalanceQuery", function () {
+    let originalFetch;
+    let fetchStub;
+    let client;
+
+    /**
+     * @returns {typeof globalThis}
+     */
+    function globalObject() {
+        return typeof global !== "undefined" ? global : window;
+    }
+
+    beforeEach(function () {
+        originalFetch = globalObject().fetch;
+
+        fetchStub = sinon.stub().callsFake((url) => {
+            const body = url.includes("/tokens")
+                ? TOKENS_RESPONSE
+                : ACCOUNT_RESPONSE;
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve(body),
+            });
+        });
+
+        globalObject().fetch = fetchStub;
+
+        client = new Client();
+        client.setMirrorNetwork([`${MIRROR_HOST}:443`]);
+    });
+
+    afterEach(function () {
+        globalObject().fetch = originalFetch;
+    });
+
+    it("should accept an AccountId instance and a string", function () {
+        const id = new AccountId(123);
+
+        expect(
+            new MirrorNodeAccountBalanceQuery().setAccountId(id).accountId,
+        ).to.equal(id);
+        expect(
+            new MirrorNodeAccountBalanceQuery()
+                .setAccountId("0.0.123")
+                .accountId.toString(),
+        ).to.equal("0.0.123");
+        expect(
+            new MirrorNodeAccountBalanceQuery({
+                accountId: "0.0.123",
+            }).accountId.toString(),
+        ).to.equal("0.0.123");
+    });
+
+    it("should accept a ContractId instance and a string", function () {
+        const id = new ContractId(456);
+
+        expect(
+            new MirrorNodeAccountBalanceQuery().setContractId(id).contractId,
+        ).to.equal(id);
+        expect(
+            new MirrorNodeAccountBalanceQuery()
+                .setContractId("0.0.456")
+                .contractId.toString(),
+        ).to.equal("0.0.456");
+    });
+
+    it("should throw on a malformed id without performing a request", function () {
+        expect(() =>
+            new MirrorNodeAccountBalanceQuery().setAccountId("not-an-id"),
+        ).to.throw();
+        expect(fetchStub.called).to.be.false;
+    });
+
+    it("should reject an account id and a contract id at the same time", function () {
+        expect(() =>
+            new MirrorNodeAccountBalanceQuery()
+                .setAccountId("0.0.123")
+                .setContractId("0.0.456"),
+        ).to.throw(/either an account ID or a contract ID/);
+
+        expect(() =>
+            new MirrorNodeAccountBalanceQuery()
+                .setContractId("0.0.456")
+                .setAccountId("0.0.123"),
+        ).to.throw(/either an account ID or a contract ID/);
+    });
+
+    it("should reject when no id is set", async function () {
+        let message = "";
+        try {
+            await new MirrorNodeAccountBalanceQuery().execute(client);
+        } catch (error) {
+            message = error.message;
+        }
+        expect(message).to.include("requires an account ID or a contract ID");
+        expect(fetchStub.called).to.be.false;
+    });
+
+    it("should query the accounts endpoint by shard.realm.num", async function () {
+        await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(fetchStub.firstCall.args[0]).to.equal(
+            `${BASE_URL}/accounts/0.0.123`,
+        );
+        expect(fetchStub.secondCall.args[0]).to.equal(
+            `${BASE_URL}/accounts/0.0.123/tokens`,
+        );
+    });
+
+    it("should query a contract id through the accounts endpoint", async function () {
+        await new MirrorNodeAccountBalanceQuery()
+            .setContractId("0.0.456")
+            .execute(client);
+
+        expect(fetchStub.firstCall.args[0]).to.equal(
+            `${BASE_URL}/accounts/0.0.456`,
+        );
+    });
+
+    it("should query an evm address as bare hex", async function () {
+        const evmAddress = "67900ac7415136de991114c8d7210c7a6617f0ee";
+
+        await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(AccountId.fromString(evmAddress))
+            .execute(client);
+
+        expect(fetchStub.firstCall.args[0]).to.equal(
+            `${BASE_URL}/accounts/${evmAddress}`,
+        );
+    });
+
+    it("should query an alias key as a base32 alias", async function () {
+        const publicKey = PublicKey.fromString(
+            "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7",
+        );
+        const accountId = new AccountId(0, 0, 0, publicKey);
+        const alias = EntityIdHelper.publicKeyToAlias(publicKey);
+
+        await new MirrorNodeAccountBalanceQuery()
+            .setAccountId(accountId)
+            .execute(client);
+
+        expect(alias).to.not.be.null;
+        expect(fetchStub.firstCall.args[0]).to.equal(
+            `${BASE_URL}/accounts/${alias}`,
+        );
+    });
+
+    it("should return the hbar, token and decimal balances", async function () {
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(balance.hbars.toTinybars().toString()).to.equal("5000000000");
+
+        // The `/tokens` endpoint wins — the truncated `balance.tokens`
+        // preview (0.0.999) must not appear.
+        expect(balance.tokens.get(TokenId.fromString("0.0.999"))).to.be.null;
+        expect(
+            balance.tokens.get(TokenId.fromString("0.0.111")).toString(),
+        ).to.equal("250");
+        expect(
+            balance.tokens.get(TokenId.fromString("0.0.222")).toString(),
+        ).to.equal("7");
+        expect(
+            balance.tokenDecimals.get(TokenId.fromString("0.0.111")),
+        ).to.equal(3);
+        expect(
+            balance.tokenDecimals.get(TokenId.fromString("0.0.222")),
+        ).to.equal(0);
+    });
+});

--- a/test/unit/node/MirrorNodeAccountBalanceQuery.js
+++ b/test/unit/node/MirrorNodeAccountBalanceQuery.js
@@ -2,12 +2,12 @@
 
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { AccountId, TokenId } from "../../../src/index.js";
+import { AccountId } from "../../../src/index.js";
 import MirrorNodeAccountBalanceQuery from "../../../src/query/MirrorNodeAccountBalanceQuery.js";
 import NativeClient from "../../../src/client/NativeClient.js";
 
 const MIRROR_HOST = "balance-mirror.example.com";
-const ACCOUNTS_URL = `https://${MIRROR_HOST}/api/v1/accounts/0.0.123`;
+const BALANCES_URL = `https://${MIRROR_HOST}/api/v1/balances`;
 
 const server = setupServer();
 
@@ -38,42 +38,18 @@ describe("MirrorNodeAccountBalanceQuery (wire)", function () {
         server.close();
     });
 
-    it("should parse the hbar balance and accumulate every token page", async function () {
-        let tokensRequests = 0;
+    it("should send account.id and parse the hbar balance", async function () {
+        let accountIdParam = null;
 
         server.use(
-            http.get(ACCOUNTS_URL, () =>
-                HttpResponse.json({
-                    account: "0.0.123",
-                    balance: {
-                        balance: 123456789,
-                        tokens: [{ token_id: "0.0.999", balance: 1 }],
-                    },
-                }),
-            ),
-            http.get(`${ACCOUNTS_URL}/tokens`, ({ request }) => {
-                tokensRequests += 1;
-                const isSecondPage = new URL(request.url).searchParams.has(
-                    "token.id",
+            http.get(BALANCES_URL, ({ request }) => {
+                accountIdParam = new URL(request.url).searchParams.get(
+                    "account.id",
                 );
-
-                if (isSecondPage) {
-                    return HttpResponse.json({
-                        tokens: [
-                            { token_id: "0.0.333", balance: 9, decimals: 8 },
-                        ],
-                        links: { next: null },
-                    });
-                }
-
                 return HttpResponse.json({
-                    tokens: [
-                        { token_id: "0.0.111", balance: 250, decimals: 3 },
-                        { token_id: "0.0.222", balance: 7, decimals: 0 },
-                    ],
-                    links: {
-                        next: "/api/v1/accounts/0.0.123/tokens?token.id=gt:0.0.222",
-                    },
+                    timestamp: "1234567890.000000001",
+                    balances: [{ account: "0.0.123", balance: 123456789 }],
+                    links: { next: null },
                 });
             }),
         );
@@ -82,61 +58,37 @@ describe("MirrorNodeAccountBalanceQuery (wire)", function () {
             .setAccountId("0.0.123")
             .execute(client);
 
-        expect(tokensRequests).to.equal(2);
+        expect(accountIdParam).to.equal("0.0.123");
         expect(balance.hbars.toTinybars().toString()).to.equal("123456789");
-        expect(
-            balance.tokens.get(TokenId.fromString("0.0.111")).toString(),
-        ).to.equal("250");
-        expect(
-            balance.tokens.get(TokenId.fromString("0.0.222")).toString(),
-        ).to.equal("7");
-        expect(
-            balance.tokens.get(TokenId.fromString("0.0.333")).toString(),
-        ).to.equal("9");
-        expect(
-            balance.tokenDecimals.get(TokenId.fromString("0.0.111")),
-        ).to.equal(3);
-        expect(
-            balance.tokenDecimals.get(TokenId.fromString("0.0.222")),
-        ).to.equal(0);
-        expect(
-            balance.tokenDecimals.get(TokenId.fromString("0.0.333")),
-        ).to.equal(8);
-        expect(balance.tokens.get(TokenId.fromString("0.0.999"))).to.be.null;
     });
 
-    it("should not retry a 404", async function () {
+    it("should return zero hbars when the account does not exist", async function () {
         let requests = 0;
 
         server.use(
-            http.get(ACCOUNTS_URL, () => {
+            http.get(BALANCES_URL, () => {
                 requests += 1;
-                return HttpResponse.json(
-                    { _status: { messages: [{ message: "Not found" }] } },
-                    { status: 404 },
-                );
+                return HttpResponse.json({
+                    timestamp: null,
+                    balances: [],
+                    links: { next: null },
+                });
             }),
         );
 
-        let message = "";
-        try {
-            await new MirrorNodeAccountBalanceQuery()
-                .setAccountId("0.0.123")
-                .execute(client);
-        } catch (error) {
-            message = error.message;
-        }
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
 
         expect(requests).to.equal(1);
-        expect(message).to.include("404");
-        expect(message).to.include("Not found");
+        expect(balance.hbars.toTinybars().toString()).to.equal("0");
     });
 
     it("should not retry a 400", async function () {
         let requests = 0;
 
         server.use(
-            http.get(ACCOUNTS_URL, () => {
+            http.get(BALANCES_URL, () => {
                 requests += 1;
                 return HttpResponse.json(
                     {
@@ -167,19 +119,17 @@ describe("MirrorNodeAccountBalanceQuery (wire)", function () {
         let requests = 0;
 
         server.use(
-            http.get(ACCOUNTS_URL, () => {
+            http.get(BALANCES_URL, () => {
                 requests += 1;
                 if (requests === 1) {
                     return new HttpResponse(null, { status: 503 });
                 }
                 return HttpResponse.json({
-                    account: "0.0.123",
-                    balance: { balance: 42 },
+                    timestamp: "1234567890.000000001",
+                    balances: [{ account: "0.0.123", balance: 42 }],
+                    links: { next: null },
                 });
             }),
-            http.get(`${ACCOUNTS_URL}/tokens`, () =>
-                HttpResponse.json({ tokens: [], links: { next: null } }),
-            ),
         );
 
         const balance = await new MirrorNodeAccountBalanceQuery()
@@ -188,6 +138,5 @@ describe("MirrorNodeAccountBalanceQuery (wire)", function () {
 
         expect(requests).to.equal(2);
         expect(balance.hbars.toTinybars().toString()).to.equal("42");
-        expect(balance.tokens.size).to.equal(0);
     });
 });

--- a/test/unit/node/MirrorNodeAccountBalanceQuery.js
+++ b/test/unit/node/MirrorNodeAccountBalanceQuery.js
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { AccountId, TokenId } from "../../../src/index.js";
+import MirrorNodeAccountBalanceQuery from "../../../src/query/MirrorNodeAccountBalanceQuery.js";
+import NativeClient from "../../../src/client/NativeClient.js";
+
+const MIRROR_HOST = "balance-mirror.example.com";
+const ACCOUNTS_URL = `https://${MIRROR_HOST}/api/v1/accounts/0.0.123`;
+
+const server = setupServer();
+
+describe("MirrorNodeAccountBalanceQuery (wire)", function () {
+    let client;
+
+    beforeAll(() => {
+        server.listen();
+    });
+
+    beforeEach(function () {
+        client = NativeClient.forNetwork({
+            "node.example.com:50211": new AccountId(3),
+        });
+        client.setMirrorNetwork([`${MIRROR_HOST}:443`]);
+        // Keep the retry backoff short so the retry test stays fast.
+        client.setMinBackoff(1).setMaxBackoff(1);
+    });
+
+    afterEach(function () {
+        if (client) {
+            client.close();
+        }
+        server.resetHandlers();
+    });
+
+    afterAll(() => {
+        server.close();
+    });
+
+    it("should parse the hbar balance and accumulate every token page", async function () {
+        let tokensRequests = 0;
+
+        server.use(
+            http.get(ACCOUNTS_URL, () =>
+                HttpResponse.json({
+                    account: "0.0.123",
+                    balance: {
+                        balance: 123456789,
+                        tokens: [{ token_id: "0.0.999", balance: 1 }],
+                    },
+                }),
+            ),
+            http.get(`${ACCOUNTS_URL}/tokens`, ({ request }) => {
+                tokensRequests += 1;
+                const isSecondPage = new URL(request.url).searchParams.has(
+                    "token.id",
+                );
+
+                if (isSecondPage) {
+                    return HttpResponse.json({
+                        tokens: [
+                            { token_id: "0.0.333", balance: 9, decimals: 8 },
+                        ],
+                        links: { next: null },
+                    });
+                }
+
+                return HttpResponse.json({
+                    tokens: [
+                        { token_id: "0.0.111", balance: 250, decimals: 3 },
+                        { token_id: "0.0.222", balance: 7, decimals: 0 },
+                    ],
+                    links: {
+                        next: "/api/v1/accounts/0.0.123/tokens?token.id=gt:0.0.222",
+                    },
+                });
+            }),
+        );
+
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(tokensRequests).to.equal(2);
+        expect(balance.hbars.toTinybars().toString()).to.equal("123456789");
+        expect(
+            balance.tokens.get(TokenId.fromString("0.0.111")).toString(),
+        ).to.equal("250");
+        expect(
+            balance.tokens.get(TokenId.fromString("0.0.222")).toString(),
+        ).to.equal("7");
+        expect(
+            balance.tokens.get(TokenId.fromString("0.0.333")).toString(),
+        ).to.equal("9");
+        expect(
+            balance.tokenDecimals.get(TokenId.fromString("0.0.111")),
+        ).to.equal(3);
+        expect(
+            balance.tokenDecimals.get(TokenId.fromString("0.0.222")),
+        ).to.equal(0);
+        expect(
+            balance.tokenDecimals.get(TokenId.fromString("0.0.333")),
+        ).to.equal(8);
+        expect(balance.tokens.get(TokenId.fromString("0.0.999"))).to.be.null;
+    });
+
+    it("should not retry a 404", async function () {
+        let requests = 0;
+
+        server.use(
+            http.get(ACCOUNTS_URL, () => {
+                requests += 1;
+                return HttpResponse.json(
+                    { _status: { messages: [{ message: "Not found" }] } },
+                    { status: 404 },
+                );
+            }),
+        );
+
+        let message = "";
+        try {
+            await new MirrorNodeAccountBalanceQuery()
+                .setAccountId("0.0.123")
+                .execute(client);
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(requests).to.equal(1);
+        expect(message).to.include("404");
+        expect(message).to.include("Not found");
+    });
+
+    it("should not retry a 400", async function () {
+        let requests = 0;
+
+        server.use(
+            http.get(ACCOUNTS_URL, () => {
+                requests += 1;
+                return HttpResponse.json(
+                    {
+                        _status: {
+                            messages: [{ message: "Invalid parameter" }],
+                        },
+                    },
+                    { status: 400 },
+                );
+            }),
+        );
+
+        let message = "";
+        try {
+            await new MirrorNodeAccountBalanceQuery()
+                .setAccountId("0.0.123")
+                .execute(client);
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(requests).to.equal(1);
+        expect(message).to.include("400");
+        expect(message).to.include("Invalid parameter");
+    });
+
+    it("should retry a 503 and return the balance on the next attempt", async function () {
+        let requests = 0;
+
+        server.use(
+            http.get(ACCOUNTS_URL, () => {
+                requests += 1;
+                if (requests === 1) {
+                    return new HttpResponse(null, { status: 503 });
+                }
+                return HttpResponse.json({
+                    account: "0.0.123",
+                    balance: { balance: 42 },
+                });
+            }),
+            http.get(`${ACCOUNTS_URL}/tokens`, () =>
+                HttpResponse.json({ tokens: [], links: { next: null } }),
+            ),
+        );
+
+        const balance = await new MirrorNodeAccountBalanceQuery()
+            .setAccountId("0.0.123")
+            .execute(client);
+
+        expect(requests).to.equal(2);
+        expect(balance.hbars.toTinybars().toString()).to.equal("42");
+        expect(balance.tokens.size).to.equal(0);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the mirror-node replacement for the deprecated `AccountBalanceQuery` per #4286, following the [migration proposal](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/account-balance-query-mirror-node-migration.md) as merged (updated by [sdk-collaboration-hub#280](https://github.com/hiero-ledger/sdk-collaboration-hub/pull/280) after mirror node team review). New standalone class following the existing mirror REST query pattern (`MirrorNodeContractCallQuery`, `FeeEstimateQuery`) — plain HTTP, no `Query` base class, no payment.

```js
const balance = await new MirrorNodeAccountBalanceQuery()
    .setAccountId("0.0.12345") // or EVM address / alias / contract ID
    .execute(client);
console.log(balance.hbars.toString());
```

- Single `GET /api/v1/balances?account.id={id}` request; returns the new read-only `MirrorNodeAccountBalance` type carrying `hbars` only. Token balances are deliberately out of scope per the proposal (the balances endpoint does not paginate them, and unbounded `/tokens` pagination is a mirror node DDoS risk).
- `setAccountId` accepts `shard.realm.num`, EVM address, public-key alias, and contract IDs (the balances endpoint resolves all forms — no separate `setContractId`). Alias-key IDs are sent as the base32 alias the mirror node requires; the DER-hex form from `AccountId.toString()` gets a 400.
- A non-existent account yields an empty `balances` array (HTTP 200), returned as zero hbars per the proposal.
- 400 → immediate error carrying the mirror error detail, no retry; 5xx/network failures → exponential backoff from `client.minBackoff` up to `client.maxAttempts`. `requestTimeout` (parameter or client default) is a total operation budget across all attempts, and `AbortSignal.timeout` is guarded for React Native.
- Eventual consistency (mirror ingest lag) and the 2^53−1 JSON number precision limit are documented in the class JSDoc.

## Testing

- 13 unit tests: isomorphic suite (setters, ID-form resolution to the `account.id` parameter, empty-array → zero, immutability) + MSW wire suite (parameter and parsing, empty-array → zero, 400 no-retry, 503-then-200 retry).
- Integration test (CI solo network): operator balance via polling with a deadline (no fixed sleeps), non-existent account → zero hbars.
- Live smoke against the public testnet mirror node: number, base32-alias, and EVM-address forms of the same account return identical balances; non-existent account returns zero.
- `task build` clean (tsc strict JSDoc, eslint, dpdm, prettier, compile); example `examples/account/get-balance-mirror-node.js` included.

## Notes for reviewers

- Extracting the shared mirror REST retry loop into `mirrorRestRetry.js` (also used in spirit by `FeeEstimateQuery` / `RegisteredNodeAddressBookQuery`) stays a follow-up, as agreed in the earlier review thread.
- `main` currently has prettier drift in `src/channel/NativeMirrorChannel.js` and `test/unit/NativeChannel.js`; this PR deliberately excludes those files.

Fixes #4286