### PR TITLE
fix(examples): prevent never-exiting examples from hanging CI

### DIFF
--- a/examples/consensus/pub-sub.js
+++ b/examples/consensus/pub-sub.js
@@ -46,7 +46,7 @@ async function main() {
         // need to wait before the mirror node can see new topic
         await setTimeout(5000);
 
-        new TopicMessageQuery()
+        const handle = new TopicMessageQuery()
             .setTopicId(topicId)
             .setStartTime(0)
             .subscribe(
@@ -76,14 +76,19 @@ async function main() {
             console.log(`Sent message ${i}`);
             await setTimeout(5000);
         }
-    } catch (error) {
-        console.error(error);
-    }
 
-    client.close();
+        handle.unsubscribe();
+    } finally {
+        client.close();
+    }
 }
 
-void main();
+void main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
 
 const bigContents = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur aliquam augue sem, ut mattis dui laoreet a. Curabitur consequat est euismod, scelerisque metus et, tristique dui. Nulla commodo mauris ut faucibus ultricies. Quisque venenatis nisl nec augue tempus, at efficitur elit eleifend. Duis pharetra felis metus, sed dapibus urna vehicula id. Duis non venenatis turpis, sit amet ornare orci. Donec non interdum quam. Sed finibus nunc et risus finibus, non sagittis lorem cursus. Proin pellentesque tempor aliquam. Sed congue nisl in enim bibendum, condimentum vehicula nisi feugiat.

--- a/examples/run-all-examples.js
+++ b/examples/run-all-examples.js
@@ -33,11 +33,18 @@ const concurrency = Math.max(
     1,
     parseInt(process.env.EXAMPLES_CONCURRENCY || "4", 10),
 );
+// An example that never exits must not stall the whole run until the
+// CI job-level timeout (6 hours) kills it; kill it here instead.
+const exampleTimeoutMs = Math.max(
+    1000,
+    parseInt(process.env.EXAMPLES_TIMEOUT_MS || "300000", 10),
+);
 
 /**
  * @typedef {object} ExampleRunResult
  * @property {string} file
  * @property {number} code
+ * @property {boolean} timedOut
  */
 
 /**
@@ -50,10 +57,19 @@ function runExample(examplePath, file) {
         const child = spawn(cmd, [examplePath], {
             stdio: "ignore",
         });
+        let timedOut = false;
+        const timer = setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGKILL");
+        }, exampleTimeoutMs);
         child.on("close", (code) => {
-            resolve({ file, code: code ?? -1 });
+            clearTimeout(timer);
+            resolve({ file, code: code ?? -1, timedOut });
         });
-        child.on("error", reject);
+        child.on("error", (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
     });
 }
 
@@ -78,8 +94,17 @@ async function runInParallel(examples, maxConcurrency) {
             console.log(
                 `\n⏳ ${String(index + 1)}/${String(total)}. Running ${file}...`,
             );
-            const { file: f, code } = await runExample(examplePath, file);
-            if (code === 0) {
+            const {
+                file: f,
+                code,
+                timedOut,
+            } = await runExample(examplePath, file);
+            if (timedOut) {
+                failed += 1;
+                console.log(
+                    `❌ ${f} timed out after ${String(exampleTimeoutMs)} ms and was killed.`,
+                );
+            } else if (code === 0) {
                 completed += 1;
                 console.log(`✅ ${f} completed.`);
             } else {


### PR DESCRIPTION
## Summary

Every recent "Run examples using Node 22" hang (6 hours, then killed by the job-level timeout and reported as "cancelled") traces to `examples/consensus/pub-sub.js`:

- It discards its `TopicMessageQuery` subscription handle (never unsubscribes) and, unlike its `pub-sub-chunked.js` / `pub-sub-with-submit-key.js` siblings, ends with a bare `void main();` and no `process.exit`. The leaked mirror subscription keeps the child process alive after `client.close()`, so it never exits and `run-all-examples.js` waits on it forever.
- The old top-level `consensus-pub-sub*.js` copies are in `excludedJSFile` for exactly this reason, but #4047 moved the examples under `consensus/` and the subdirectory scan applies no per-file exclusions, so the new copy escaped the list.
- The hang is intermittent because the worker loop in `run-all-examples.js` consumes two indexes per iteration (both the `for` update and the loop body do `index = nextIndex++`), silently skipping roughly half the examples nondeterministically; `pub-sub.js` is only sometimes picked. Evidence from [run 31494466667](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/31494466667): 48 examples started, 47 finished, `consensus/pub-sub.js` started and never finished, log silent for the remaining 6 hours. Runs where it happens to be skipped pass.

Changes:

- `consensus/pub-sub.js`: keep the subscription handle and `unsubscribe()` after the send loop, close the client in `finally`, and end with the same `process.exit(0)` / `process.exit(1)` pattern as its siblings (this also stops it exiting 0 on swallowed errors).
- `run-all-examples.js`: add a per-example timeout (default 5 minutes, overridable via `EXAMPLES_TIMEOUT_MS`). A child that outlives it is SIGKILLed and reported as `timed out ... and was killed`, so any future never-exiting example fails the job in minutes instead of hanging it for 6 hours.

The index double-increment bug is deliberately left for a follow-up: fixing it re-enables the roughly-half of the example set that is currently being skipped per run, which needs its own validation pass.

## Testing

- Sandbox run of the modified runner over three fake examples (pass / exit 3 / never exits): the hanging one is killed at the configured timeout and reported as failed, the run finishes in ~2 s with exit code 1 instead of hanging.
- `node --check` and prettier clean on both files.
