### PR TITLE
fix(jsdoc): use generic Client<Channel, MirrorChannel> in ScheduleInfoQuery

### DIFF
--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 
@@ -87,7 +88,7 @@ export default class ScheduleInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {Client} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {


### PR DESCRIPTION
**Description**:

`pnpm exec eslint src/schedule/ScheduleInfoQuery.js` reports three `jsdoc/reject-any-type` warnings because the `Client` type is left as the wildcard `*`:

- line 22: `@typedef {import("../client/Client.js").default<*, *>} Client`
- line 90: `@param {import("../client/Client.js").default<Channel, *>} client` on `getCost()`

This PR narrows the wildcards to the specific channel types:

- Added a `MirrorChannel` typedef and changed the `Client` typedef to `import("../client/Client.js").default<Channel, MirrorChannel>`.
- Changed the `getCost()` `@param` to reuse the already-narrowed `{Client}` typedef instead of re-importing and re-narrowing the type inline (as requested in review feedback on #3812).

JSDoc-only change — no runtime behavior or public API changes, scope limited to `src/schedule/ScheduleInfoQuery.js`.

**Verification**:
- `pnpm exec eslint src/schedule/ScheduleInfoQuery.js` — clean, the three `jsdoc/reject-any-type` warnings are gone
- `npx tsc` — no new errors vs `main`
- Schedule unit tests pass (`test/unit/ScheduleInfo.js`, 8/8)

**Related issue(s)**:

Closes #3799

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)