### PR TITLE
test: add unit tests for TokenReference

### DIFF
--- a/test/unit/TokenReference.js
+++ b/test/unit/TokenReference.js
@@ -1,0 +1,37 @@
+import TokenReference from "../../src/token/TokenReference.js";
+import TokenId from "../../src/token/TokenId.js";
+import NftId from "../../src/token/NftId.js";
+
+describe("TokenReference", function () {
+    it("initializes fungibleToken and nft to null", function () {
+        const reference = new TokenReference();
+        expect(reference.fungibleToken).to.be.null;
+        expect(reference.nft).to.be.null;
+    });
+
+    it("maps fungibleToken from protobuf", function () {
+        const tokenId = new TokenId(0, 0, 5);
+        const reference = TokenReference._fromProtobuf({
+            fungibleToken: tokenId._toProtobuf(),
+        });
+        expect(reference.fungibleToken).to.be.instanceOf(TokenId);
+        expect(reference.fungibleToken.toString()).to.equal("0.0.5");
+        expect(reference.nft).to.be.null;
+    });
+
+    it("maps nft from protobuf", function () {
+        const nftId = new NftId(new TokenId(0, 0, 5), 7);
+        const reference = TokenReference._fromProtobuf({
+            nft: nftId._toProtobuf(),
+        });
+        expect(reference.nft).to.be.instanceOf(NftId);
+        expect(reference.nft.toString()).to.equal("0.0.5/7");
+        expect(reference.fungibleToken).to.be.null;
+    });
+
+    it("maps an empty protobuf reference to nulls", function () {
+        const reference = TokenReference._fromProtobuf({});
+        expect(reference.fungibleToken).to.be.null;
+        expect(reference.nft).to.be.null;
+    });
+});


### PR DESCRIPTION
**Description**:

`src/token/TokenReference.js` had 0% direct unit test coverage — only the `_toProtobuf` direction was exercised indirectly through the `TokenRejectTransaction` tests.

This PR adds `test/unit/TokenReference.js` with four tests covering the actual class API:

- the constructor initializes `fungibleToken` and `nft` to `null`
- `_fromProtobuf()` maps a protobuf `fungibleToken` field to a `TokenId` (and leaves `nft` as `null`)
- `_fromProtobuf()` maps a protobuf `nft` field to an `NftId` (and leaves `fungibleToken` as `null`)
- `_fromProtobuf()` maps an empty protobuf reference to `null` for both fields

Note: the issue's original description referenced a `constructor(props)` accepting a `tokenId`, which never existed in this file (verified via `git log -S` over its full history). The issue body has been corrected to describe the real class, and these tests target that.

Test-only change — no runtime behavior or public API changes, scope limited to the new test file.

**Verification**:
- `npx vitest run --config=test/vitest-node.config.ts test/unit/TokenReference.js` — 4/4 pass
- `npx prettier --check test/unit/TokenReference.js` — clean
- `npx tsc` — no errors

**Related issue(s)**:

Closes #4024

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)