### PR TITLE
fix(transaction): reject bodies that set more than one data field

### DIFF
--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -83,26 +83,28 @@ export const TRANSACTION_REGISTRY = new Map();
  * @type {Set<number>}
  */
 let dataFieldNumbers = new Set();
-let dataFieldRegistrySize = -1;
 
 /**
  * @returns {Set<number>}
  */
 function getDataFieldNumbers() {
-    if (
-        dataFieldNumbers.size === 0 ||
-        TRANSACTION_REGISTRY.size !== dataFieldRegistrySize
-    ) {
-        /** @type {Set<number>} */
-        const numbers = new Set();
-        for (const name of TRANSACTION_REGISTRY.keys()) {
+    if (dataFieldNumbers.size === 0) {
+        const prototype = HieroProto.proto.TransactionBody.prototype;
+        for (const name of Object.keys(prototype)) {
+            // The generated `data` oneof getter returns the name only if it
+            // belongs to the oneof, which lets us test membership.
+            const carrier = Object.create(prototype);
+            carrier[name] = 1;
+            if (carrier.data !== name) {
+                continue;
+            }
             const probe = HieroProto.proto.TransactionBody.encode({
                 [name]: {},
             }).finish();
-            numbers.add(HieroProto.Reader.create(probe).uint32() >>> 3);
+            dataFieldNumbers.add(
+                HieroProto.Reader.create(probe).uint32() >>> 3,
+            );
         }
-        dataFieldNumbers = numbers;
-        dataFieldRegistrySize = TRANSACTION_REGISTRY.size;
     }
     return dataFieldNumbers;
 }

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -75,6 +75,70 @@ function isMultiTransactionIdType(transactionDataCase) {
 export const TRANSACTION_REGISTRY = new Map();
 
 /**
+ * Field numbers of the `data` oneof on `TransactionBody`, i.e. the transaction
+ * type fields. A valid body sets exactly one of these. Derived from the
+ * transaction registry so it stays in sync as transaction types are added.
+ * Rebuilt when the registry grows, because types register lazily on import.
+ *
+ * @type {Set<number>}
+ */
+let dataFieldNumbers = new Set();
+let dataFieldRegistrySize = -1;
+
+/**
+ * @returns {Set<number>}
+ */
+function getDataFieldNumbers() {
+    if (
+        dataFieldNumbers.size === 0 ||
+        TRANSACTION_REGISTRY.size !== dataFieldRegistrySize
+    ) {
+        /** @type {Set<number>} */
+        const numbers = new Set();
+        for (const name of TRANSACTION_REGISTRY.keys()) {
+            const probe = HieroProto.proto.TransactionBody.encode({
+                [name]: {},
+            }).finish();
+            numbers.add(HieroProto.Reader.create(probe).uint32() >>> 3);
+        }
+        dataFieldNumbers = numbers;
+        dataFieldRegistrySize = TRANSACTION_REGISTRY.size;
+    }
+    return dataFieldNumbers;
+}
+
+/**
+ * Reject a transaction body that sets more than one `data` field.
+ *
+ * A crafted `TransactionBody` can carry several `data` fields on the wire.
+ * protobufjs keeps only the last one when decoding, so the extra fields are
+ * invisible on the decoded object and cannot be counted there. We inspect the
+ * raw bytes instead, before decoding, so an ambiguous body is refused.
+ *
+ * @param {Uint8Array} bodyBytes
+ */
+function assertSingleDataField(bodyBytes) {
+    if (bodyBytes == null || bodyBytes.length === 0) {
+        return;
+    }
+    const dataFields = getDataFieldNumbers();
+    const reader = HieroProto.Reader.create(bodyBytes);
+    let count = 0;
+    while (reader.pos < reader.len) {
+        const tag = reader.uint32();
+        if (dataFields.has(tag >>> 3)) {
+            count++;
+        }
+        reader.skipType(tag & 7);
+    }
+    if (count > 1) {
+        throw new Error(
+            "transaction body sets more than one data field; refusing to decode an ambiguous transaction",
+        );
+    }
+}
+
+/**
  * Base class for all transactions that may be submitted to Hedera.
  *
  * @abstract
@@ -305,6 +369,7 @@ export default class Transaction extends Executable {
             }
 
             if (transaction.bodyBytes && transaction.bodyBytes.length != 0) {
+                assertSingleDataField(transaction.bodyBytes);
                 // Decode a transaction
                 const body = HieroProto.proto.TransactionBody.decode(
                     transaction.bodyBytes,
@@ -365,6 +430,7 @@ export default class Transaction extends Executable {
                 signedTransactions.push(signedTransaction);
 
                 // Decode a transaction body
+                assertSingleDataField(signedTransaction.bodyBytes);
                 const body = HieroProto.proto.TransactionBody.decode(
                     signedTransaction.bodyBytes,
                 );

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -77,8 +77,8 @@ export const TRANSACTION_REGISTRY = new Map();
 /**
  * Field numbers of the `data` oneof on `TransactionBody`, i.e. the transaction
  * type fields. A valid body sets exactly one of these. Derived from the
- * transaction registry so it stays in sync as transaction types are added.
- * Rebuilt when the registry grows, because types register lazily on import.
+ * generated protobuf prototype so it covers every field in the oneof, even
+ * transaction types the SDK does not register (e.g. `systemDelete`).
  *
  * @type {Set<number>}
  */
@@ -93,14 +93,16 @@ function getDataFieldNumbers() {
         for (const name of Object.keys(prototype)) {
             // The generated `data` oneof getter returns the name only if it
             // belongs to the oneof, which lets us test membership.
-            const carrier = Object.create(prototype);
-            carrier[name] = 1;
+            const carrier = new HieroProto.proto.TransactionBody(
+                /** @type {HieroProto.proto.ITransactionBody} */ ({
+                    [name]: {},
+                }),
+            );
             if (carrier.data !== name) {
                 continue;
             }
-            const probe = HieroProto.proto.TransactionBody.encode({
-                [name]: {},
-            }).finish();
+            const probe =
+                HieroProto.proto.TransactionBody.encode(carrier).finish();
             dataFieldNumbers.add(
                 HieroProto.Reader.create(probe).uint32() >>> 3,
             );

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -314,6 +314,30 @@ describe("Transaction", function () {
         );
     });
 
+    it("fromBytes rejects a body that smuggles a data field the SDK does not register", function () {
+        // systemDelete has no entry in the transaction registry, but it is
+        // still a data field, so pairing it with cryptoTransfer is ambiguous.
+        const del = HieroProto.proto.TransactionBody.encode({
+            systemDelete: {},
+        }).finish();
+        const transfer = HieroProto.proto.TransactionBody.encode({
+            cryptoTransfer: {},
+        }).finish();
+        const smuggled = new Uint8Array([...del, ...transfer]);
+
+        const signedTransactionBytes =
+            HieroProto.proto.SignedTransaction.encode({
+                bodyBytes: smuggled,
+            }).finish();
+        const list = HieroProto.proto.TransactionList.encode({
+            transactionList: [{ signedTransactionBytes }],
+        }).finish();
+
+        expect(() => Transaction.fromBytes(list)).to.throw(
+            /more than one data field/,
+        );
+    });
+
     it("fromBytes fails for empty bytes", function () {
         expect(() => Transaction.fromBytes(new Uint8Array())).to.throw(
             "cannot deserialize a transaction from empty bytes",

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -290,6 +290,30 @@ describe("Transaction", function () {
         }
     });
 
+    it("fromBytes rejects a body that sets more than one data field", function () {
+        // Two different data fields (cryptoUpdateAccount and cryptoDelete)
+        // smuggled onto one body's wire bytes. A valid body sets only one.
+        const update = HieroProto.proto.TransactionBody.encode({
+            cryptoUpdateAccount: {},
+        }).finish();
+        const del = HieroProto.proto.TransactionBody.encode({
+            cryptoDelete: {},
+        }).finish();
+        const smuggled = new Uint8Array([...update, ...del]);
+
+        const signedTransactionBytes =
+            HieroProto.proto.SignedTransaction.encode({
+                bodyBytes: smuggled,
+            }).finish();
+        const list = HieroProto.proto.TransactionList.encode({
+            transactionList: [{ signedTransactionBytes }],
+        }).finish();
+
+        expect(() => Transaction.fromBytes(list)).to.throw(
+            /more than one data field/,
+        );
+    });
+
     it("fromBytes fails for empty bytes", function () {
         expect(() => Transaction.fromBytes(new Uint8Array())).to.throw(
             "cannot deserialize a transaction from empty bytes",


### PR DESCRIPTION
## What

`Transaction.fromBytes` now rejects a transaction body that sets more than one `data` field.

## Why

A transaction body should set exactly one `data` field, which is the transaction type. It is possible to craft bytes that set more than one. When that happens, protobufjs keeps only the last field and drops the rest while decoding. The dropped fields are not visible on the decoded object, so they cannot be checked after decoding. The body is ambiguous.

This is a low severity, defense-in-depth fix. It only affects already-trusted input, such as an enrolled member or a shared transaction file. There is no known outsider path.

## How

Before decoding, we read the raw body bytes and count how many fields belong to the transaction `data` group. If more than one is set, we throw and refuse to build the transaction. The list of `data` field numbers is taken from the transaction registry, so it stays correct as new transaction types are added.

We do not re-encode and compare against the original bytes. That is unreliable because different SDKs order fields differently.

## Tests

- Added a unit test that builds a body with two `data` fields and checks that `fromBytes` throws.
- Ran the Transaction unit tests and they pass.

Closes #4337
