### PR TITLE
ci: harden workflow token permissions and pin tck base images

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,14 +9,16 @@ defaults:
     shell: bash
 
 permissions:
-  pages: write
   contents: read
-  id-token: write
 
 jobs:
   build-and-deploy-docs:
     name: Documentation
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 permissions:
-  statuses: write
+  contents: read
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -23,6 +23,8 @@ jobs:
   title-check:
     name: Title Check
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -20,8 +20,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 env:
   HIERO_PROTO_PKG_NAME: "@hiero-ledger/proto"
@@ -342,6 +341,8 @@ jobs:
   build-release-package:
     name: Build Release Package
     runs-on: hiero-client-sdk-linux-large
+    permissions:
+      contents: write
     env:
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false'}}
     needs:
@@ -457,6 +458,9 @@ jobs:
   publish-release:
     name: Publish Release Packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - calculate-release-args
       - build-release-package

--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS build
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN pnpm install
 COPY . .
 
 # Stage 2: Runtime
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 WORKDIR /app
 


### PR DESCRIPTION
**Description**:

Harden GitHub Actions token permissions and pin the TCK Docker base image by digest, addressing the two OpenSSF Scorecard findings that are fixable from the repository (`Token-Permissions` is currently scored 0 because `publish_release.yaml` grants `contents: write` at the workflow level).

**Changes**

Token-Permissions
* `pr_check.yml`: top-level `permissions` becomes `contents: read`; `statuses: write` moves to the `title-check` job (needed by `conventional-pr-title-action` to set the commit status).
* `publish_release.yaml`: top-level `permissions` becomes `contents: read`; `contents: write` moves to `build-release-package` (creates the GitHub release via `step-security/release-action`) and `id-token: write` moves to `publish-release` (npm publish with OIDC). The validate/safety/calculate jobs only check out code and keep read access.
* `pages.yml`: top-level `permissions` becomes `contents: read`; `pages: write` and `id-token: write` move to the single `build-and-deploy-docs` job.

Pinned-Dependencies
* `tck/Dockerfile`: pin `node:20-alpine` by digest (`sha256:fb4cd12c…`) in both build stages. Digest verified against the current manifest index with `docker buildx imagetools inspect node:20-alpine`.

| Check | Before | After (local scorecard) |
|---|---|---|
| Token-Permissions | 0 | 10 |
| Pinned-Dependencies | 8 | 9 |
| Dangerous-Workflow | 10 | 10 |
| Binary-Artifacts | 10 | 10 |

**Intentionally not changed**
* `npm install -g …` (pnpm in `tck/Dockerfile`, npm in `publish_release.yaml`, detox-cli in `react_native.yml`): global tool installs, which Scorecard flags regardless of a version suffix; left as-is rather than changing the install mechanism.
* No CodeQL workflow added: code scanning already runs through the repository's default setup (`Analyze (actions)` / `Analyze (javascript-typescript)` on every commit), and an advanced workflow cannot be used alongside default setup.
* `build.yml` keeps `pull-requests: write` at the workflow level; it is not penalised by Scorecard and I did not want to guess which job depends on it.
* `.github/dependabot.yml` already covers `github-actions` and `npm`.

**Related issue(s)**:

N/A

**Notes for reviewer**:

* `actionlint` on the three edited workflows reports only the pre-existing warnings (self-hosted runner labels, existing shellcheck notes, the `prerelease` output reference on `release-action`); nothing new.
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow` run before and after; results in the table above.
* `publish_release.yaml` and `pages.yml` only run on tags / pushes to `main`, so they cannot be exercised from this PR. The job-level scopes preserve every write the release and pages jobs used before; please double-check nothing else in those flows relied on the workflow-wide `contents: write`.
* `pr_check.yml` runs on `pull_request_target`, so the Title Check on this PR used the copy of that workflow on `main`, not this branch. The `title-check` job only needs `statuses: write`: the action reads the title from the event payload and posts a commit status, nothing else.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

