### PR TITLE
fix: serialize TokenBalanceMap balances as decimal strings

### DIFF
--- a/src/ObjectMap.js
+++ b/src/ObjectMap.js
@@ -114,14 +114,7 @@ export default class ObjectMap {
      * @returns {string}
      */
     toString() {
-        /** @type {{[key: string]: any}} */
-        const map = {};
-
-        for (const [key, value] of this._map) {
-            map[key] = value;
-        }
-
-        return JSON.stringify(map);
+        return JSON.stringify(this.toJSON());
     }
 
     toJSON() {

--- a/src/account/TokenBalanceMap.js
+++ b/src/account/TokenBalanceMap.js
@@ -20,4 +20,15 @@ export default class TokenBalanceMap extends ObjectMap {
     constructor() {
         super((s) => TokenId.fromString(s));
     }
+
+    toJSON() {
+        const obj = {};
+
+        this._map.forEach((value, key) => {
+            // @ts-ignore
+            obj[key] = value.toString();
+        });
+
+        return obj;
+    }
 }

--- a/test/unit/TokenBalanceMap.js
+++ b/test/unit/TokenBalanceMap.js
@@ -1,0 +1,30 @@
+import Long from "long";
+import TokenId from "../../src/token/TokenId.js";
+import TokenBalanceMap from "../../src/account/TokenBalanceMap.js";
+
+describe("TokenBalanceMap", function () {
+    /**
+     * @returns {TokenBalanceMap}
+     */
+    function balances() {
+        const map = new TokenBalanceMap();
+
+        map._set(new TokenId(0, 0, 9454951), Long.UZERO);
+        map._set(
+            new TokenId(0, 0, 9454946),
+            Long.fromString("18446744073709551615", true),
+        );
+
+        return map;
+    }
+
+    const expected = '{"0.0.9454951":"0","0.0.9454946":"18446744073709551615"}';
+
+    it("should serialize balances as decimal strings", function () {
+        expect(JSON.stringify(balances())).to.equal(expected);
+    });
+
+    it("should stringify balances as decimal strings", function () {
+        expect(balances().toString()).to.equal(expected);
+    });
+});


### PR DESCRIPTION
## Description

Closes #4236

`TokenBalanceMap` has no `toJSON()` of its own, so it inherits the generic one on `ObjectMap`, which copies each value into the output object unchanged:

```js
// src/ObjectMap.js
toJSON() {
    const obj = {};
    this._map.forEach((value, key) => {
        obj[key] = value; // still a Long
    });
    return obj;
}
```

The values in a `TokenBalanceMap` are `Long` instances, and `long.js` does not implement `toJSON()` (`Long.prototype.toJSON` is `undefined`). `JSON.stringify` therefore falls back to serializing the instance's enumerable fields, so `JSON.stringify(balance.tokens.toJSON())` emits

```json
{ "0.0.9454951": { "low": 0, "high": 0, "unsigned": true } }
```

instead of `{"0.0.9454951":"0"}`.

Above 2^31 the output is not just noisy, it is unusable: a max `uint64` balance comes out as `{"low":-1,"high":-1,"unsigned":true}`, which a consumer cannot read back without reimplementing the two's-complement split. This was reported downstream in hashgraph/hedera-agent-kit-js#901, where an Express `res.json()` handed those structs to API callers.

## Fix

Two commits, because the same defect is reachable through two methods.

**1. `TokenBalanceMap.toJSON()`** now stringifies each balance, which is exactly what `TokenTransferAccountMap` (the SDK's other `ObjectMap<_, Long>`) already does:

```js
toJSON() {
    const obj = {};

    this._map.forEach((value, key) => {
        // @ts-ignore
        obj[key] = value.toString();
    });

    return obj;
}
```

This adds no new failure surface: `AccountBalance.toJSON()` already calls `.toString()` on these very same values on their way into `tokens[].balance`, so anything that could throw here already throws today. It also brings the runtime output in line with the `Record<string, string>` type the issue notes is already advertised.

**2. `ObjectMap.toString()`** now delegates to `toJSON()` instead of rebuilding the object from raw values:

```js
toString() {
    return JSON.stringify(this.toJSON());
}
```

Without this, only half the bug is fixed. `toString()` never called `toJSON()`, so after commit 1 alone `` `${balance.tokens}` `` and `balance.tokens.toString()` still emitted `{"0.0.9454951":{"low":0,"high":0,"unsigned":true}}` — the same symptom by the other obvious route. The change is a net deletion of eight lines, mirrors what `AccountBalance.toString()` already does, and for every subclass that does not override `toJSON()` the output is byte-identical, since the base `toJSON()` builds the same object from the same `this._map` iteration. I verified that equivalence directly, including for `null`, nested-object and `Uint8Array` values. The one real behaviour change is `TokenNftTransferMap.toString()`, which starts emitting its own curated shape instead of raw `NftTransfer` objects; `ObjectMap.toString()`'s docstring already says "**NOTE**: This implementation is not stable and can change", and no test in the repo asserts on the `toString()` of any `ObjectMap` subclass.

The two commits are separable, so if you would rather not take the `toString()` half, drop the second one.

## Why the value stringification is not in `ObjectMap.toJSON()`

The base `toJSON()` is shared by fourteen subclasses holding different value types, and a blanket `value.toString()` there would break real code paths, not hypothetical ones:

- `NullableTokenDecimalMap` is `ObjectMap<TokenId, number | null>`, and `AbstractTokenTransferTransaction.tokenIdDecimals` populates it from `TokenTransfer.expectedDecimals`, which is explicitly `expectedDecimals || null`. A generic `.toString()` would throw a `TypeError` there.
- `SignaturePairMap` and `TransactionHashMap` are `ObjectMap<_, Uint8Array>`, whose JSON would silently change from `{"0":1,"1":2}` to `"1,2"`.
- `HbarTransferMap` and `TokenRelationshipMap` hold objects whose shape would change for every existing consumer.

So the per-value decision stays with the subclass that knows its value type, which is the pattern the SDK already uses.

## Changes

- **`src/account/TokenBalanceMap.js`** - added a `toJSON()` override that stringifies each `Long` balance, matching the existing override in `TokenTransferAccountMap`.
- **`src/ObjectMap.js`** - `toString()` delegates to `toJSON()` rather than duplicating its loop over raw values.
- **`test/unit/TokenBalanceMap.js`** - new unit test covering both routes. It uses `Long.UZERO` and max `uint64` (`18446744073709551615`) so the assertions pin decimal strings specifically: the large value is not representable as a JS number, so a fix emitting numbers instead of strings would produce `18446744073709552000` and fail.

`CHANGELOG.md` is left alone, since entries there are written per release rather than per PR.

## How this was tested

- Confirmed both new tests fail on `main`, with exactly the output from the issue. Also confirmed that with only the first commit applied the `toString()` test still fails, so the second commit is load-bearing rather than cosmetic.
- `task test:unit:node` - 158 files, 1965 tests pass.
- `task test:unit:browser` - 135 files, 1725 tests pass.
- `npx tsc` reports an identical error count before and after the change, `npx prettier --check` is clean, `npx eslint src` reports 0 errors (one fewer `any` warning than before), and `dpdm` finds no new circular dependencies.

Integration tests were not run: they need a live Solo network, and this change is pure local serialization with no network path.

One note on CI: the `Assignee Check` job fails when a PR has no assignee, and as an outside contributor I cannot set one. That red check needs a maintainer to clear.

---

I used an AI coding assistant while investigating and writing this change. I reproduced the bug, reviewed the fix and ran the test suites myself, and I am responsible for the content.
---
Disclosure: this change was prepared with AI assistance (Claude Code). The repro and tests described above were run before it was opened.
