### PR TITLE
fix: copy maxBackoff when cloning ManagedNode

### DIFF
--- a/src/ManagedNode.js
+++ b/src/ManagedNode.js
@@ -89,7 +89,7 @@ export default class ManagedNode {
             this._minBackoff = props.cloneNode.node._minBackoff;
 
             /** @type {number} */
-            this._maxBackoff = props.cloneNode.node._minBackoff;
+            this._maxBackoff = props.cloneNode.node._maxBackoff;
         } else {
             throw new Error(
                 `failed to create ManagedNode: ${JSON.stringify(props)}`,

--- a/test/unit/ManagedNode.js
+++ b/test/unit/ManagedNode.js
@@ -1,0 +1,30 @@
+import MirrorNode from "../../src/MirrorNode.js";
+
+describe("ManagedNode", function () {
+    it("preserves distinct min and max backoff when cloning", function () {
+        const minBackoff = 8000;
+        const maxBackoff = 1000 * 60 * 60;
+
+        const node = new MirrorNode({
+            newNode: {
+                address: "testnet.mirrornode.hedera.com:443",
+                channelInitFunction: () => ({}),
+            },
+        });
+
+        expect(node.minBackoff).to.equal(minBackoff);
+        expect(node.maxBackoff).to.equal(maxBackoff);
+
+        // Clone via ManagedNode cloneNode constructor path
+        const cloned = new MirrorNode({
+            cloneNode: {
+                node,
+                address: node.address,
+            },
+        });
+
+        expect(cloned.minBackoff).to.equal(minBackoff);
+        expect(cloned.maxBackoff).to.equal(maxBackoff);
+        expect(cloned.maxBackoff).to.not.equal(cloned.minBackoff);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix ManagedNode clone path copying `_maxBackoff` from `_minBackoff` instead of `_maxBackoff`, which collapsed the backoff ceiling to the floor for cloned nodes.
- Add a unit test that proves clone preserves distinct min/max backoff defaults (8000 / 3600000).

Credit: @mustafauzunn for reporting.

Fixes #4347

## Test plan
- [x] `npx vitest --config=test/vitest-node.config.ts run test/unit/ManagedNode.js` (RED on unmodified main, GREEN after fix)